### PR TITLE
Use new modlauncher method to allow faster rewriting of ATed classes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -132,6 +132,7 @@ build.dependsOn testsJar
 build.dependsOn mlserviceJar
 
 repositories {
+    mavenLocal()
     mavenCentral()
     maven {
         name = 'forge'
@@ -142,7 +143,7 @@ repositories {
 dependencies {
     testImplementation('org.junit.jupiter:junit-jupiter-api:5.5.+')
     testImplementation('org.powermock:powermock-core:2.0+')
-    testImplementation('cpw.mods:modlauncher:5.0.+')
+    testImplementation('cpw.mods:modlauncher:5.1.+')
     testImplementation('com.google.code.gson:gson:2.8.6')
     testCompileOnly(sourceSets.mlservice.output)
     testRuntime('org.junit.jupiter:junit-jupiter-engine:5.5.+')
@@ -156,10 +157,10 @@ dependencies {
     implementation('org.ow2.asm:asm-tree:7.2')
     implementation('org.apache.logging.log4j:log4j-api:2.12.+')
     implementation('org.apache.logging.log4j:log4j-core:2.12.+')
-    implementation('cpw.mods:modlauncher:5.0.+:api')
-    implementation('cpw.mods:modlauncher:5.0.+')
-    mlserviceImplementation('cpw.mods:modlauncher:5.0.+:api')
-    mlserviceImplementation('cpw.mods:modlauncher:5.0.+')
+    implementation('cpw.mods:modlauncher:5.1.+:api')
+    implementation('cpw.mods:modlauncher:5.1.+')
+    mlserviceImplementation('cpw.mods:modlauncher:5.1.+:api')
+    mlserviceImplementation('cpw.mods:modlauncher:5.1.+')
     mlserviceImplementation(sourceSets.main.output)
     antlr4Compile('org.antlr:antlr4:4.7.2')
 }

--- a/src/mlservice/java/net/minecraftforge/accesstransformer/service/AccessTransformerService.java
+++ b/src/mlservice/java/net/minecraftforge/accesstransformer/service/AccessTransformerService.java
@@ -29,8 +29,8 @@ public class AccessTransformerService implements ILaunchPluginService {
     }
 
     @Override
-    public ComputeLevel processClassNew(Phase phase, ClassNode classNode, Type classType, String reason) {
-        return AccessTransformerEngine.INSTANCE.transform(classNode, classType) ? ComputeLevel.SIMPLE_REWRITE : ComputeLevel.NO_REWRITE;
+    public int processClassNew(Phase phase, ClassNode classNode, Type classType, String reason) {
+        return AccessTransformerEngine.INSTANCE.transform(classNode, classType) ? ComputeFlags.SIMPLE_REWRITE : ComputeFlags.NO_REWRITE;
     }
 
     private static final EnumSet<Phase> YAY = EnumSet.of(Phase.BEFORE);

--- a/src/mlservice/java/net/minecraftforge/accesstransformer/service/AccessTransformerService.java
+++ b/src/mlservice/java/net/minecraftforge/accesstransformer/service/AccessTransformerService.java
@@ -28,6 +28,11 @@ public class AccessTransformerService implements ILaunchPluginService {
         return AccessTransformerEngine.INSTANCE.transform(classNode, classType);
     }
 
+    @Override
+    public ComputeLevel processClassNew(Phase phase, ClassNode classNode, Type classType, String reason) {
+        return AccessTransformerEngine.INSTANCE.transform(classNode, classType) ? ComputeLevel.SIMPLE_REWRITE : ComputeLevel.NO_REWRITE;
+    }
+
     private static final EnumSet<Phase> YAY = EnumSet.of(Phase.BEFORE);
     private static final EnumSet<Phase> NAY = EnumSet.noneOf(Phase.class);
 


### PR DESCRIPTION
This PR patches AccessTransformer to use the new processClass method of modlauncher, which improves startup performance by around 2.5-3 seconds (from 15.9 seconds to 13.0 seconds) when combined with the forge PR.
This is done by telling modlauncher that is does not need to recompute all frames just because one transformer changed the class.
The access transformer does not add or remove local variables and does not inject code, but alter existing code, which does not require maxs or frames of methods to be recomputed.
Requires https://github.com/cpw/modlauncher/pull/41
See https://gist.github.com/ichttt/98da420deabd8e904ac53fece883df16 for the raw performance test numbers