### PR TITLE
Remap class names for method and field ATs

### DIFF
--- a/src/main/java/net/minecraftforge/accesstransformer/parser/AccessTransformVisitor.java
+++ b/src/main/java/net/minecraftforge/accesstransformer/parser/AccessTransformVisitor.java
@@ -45,6 +45,7 @@ public class AccessTransformVisitor extends AtParserBaseVisitor<Void> {
         String className = entry.class_name().getText();
         String modifier = entry.keyword().getText();
         String methodName = ctx.func_name().getText();
+        className = nameHandler.translateClassName(className);
         methodName = nameHandler.translateMethodName(methodName);
         List<String> args = ctx.argument().stream().map(RuleContext::getText).collect(Collectors.toList());
         String retVal = ctx.return_value().getText();
@@ -59,6 +60,7 @@ public class AccessTransformVisitor extends AtParserBaseVisitor<Void> {
         String className = entry.class_name().getText();
         String modifier = entry.keyword().getText();
         String fieldName = ctx.getText();
+        className = nameHandler.translateClassName(className);
         fieldName = nameHandler.translateFieldName(fieldName);
         Target<?> target = new FieldTarget(className, fieldName);
         accessTransformers.add(new AccessTransformer(target, ModifierProcessor.modifier(modifier), ModifierProcessor.finalState(modifier), this.origin, ctx.getStart().getLine()));


### PR DESCRIPTION
Currently, class names are only remapped for type ATs. Field and method ATs do not remap the name of the containing type. This, as you'd expect, causes problems when you need to remap class names. 