### PR TITLE
Update to Gradle 7 and use GradleUtils

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,7 +11,7 @@ pipeline {
     environment {
         GRADLE_ARGS = '-Dorg.gradle.daemon.idletimeout=5000'
         DISCORD_WEBHOOK = credentials('forge-discord-jenkins-webhook')
-        DISCORD_PREFIX = "Job: AccessTransformer Branch: ${BRANCH_NAME} Build: #${BUILD_NUMBER}"
+        DISCORD_PREFIX = "Job: AccessTransformers Branch: ${BRANCH_NAME} Build: #${BUILD_NUMBER}"
         JENKINS_HEAD = 'https://wiki.jenkins-ci.org/download/attachments/2916393/headshot.png'
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,13 @@
+buildscript {
+    repositories {
+        maven { url = 'https://maven.minecraftforge.net/' }
+    }
+    dependencies {
+        classpath 'net.minecraftforge:GradleUtils:1.+'
+    }
+}
+
 plugins {
-    id 'org.ajoberstar.grgit' version '4.1.0'
     id 'com.github.johnrengelman.shadow' version '6.1.0'
     id 'com.github.ben-manes.versions' version '0.39.0'
     id 'antlr'
@@ -10,12 +18,13 @@ apply plugin: 'maven-publish'
 apply plugin: 'java-library'
 apply plugin: 'eclipse'
 apply plugin: 'org.javamodularity.moduleplugin'
+apply plugin: 'net.minecraftforge.gradleutils'
 
 group 'net.minecraftforge'
 
 java.toolchain.languageVersion = JavaLanguageVersion.of(16)
 
-version = grgit.describe(longDescr: true).split('-').with { "${it[0]}.${it[1]}" }
+version = gradleutils.getTagOffsetVersion()
 
 def isNonStable = { String version ->
     def stableKeyword = ['RELEASE', 'FINAL', 'GA'].any { it -> version.toUpperCase().contains(it) }
@@ -46,22 +55,22 @@ jar.manifest = manifest {
                 'Specification-Vendor': 'forge',
                 'Specification-Version': '1', // Currently version 1 of the accesstransformer specification
                 'Implementation-Title': project.name,
-                'Implementation-Version': "${project.version}+${System.getenv('BUILD_NUMBER')?:0}+${grgit.branch.current().getName()}.${grgit.head().abbreviatedId}",
+                'Implementation-Version': "${project.version}+${System.getenv('BUILD_NUMBER')?:0}+${gradleutils.gitInfo.branch}.${gradleutils.gitInfo.abbreviatedId}",
                 'Implementation-Vendor': 'forge',
                 'Implementation-Timestamp': java.time.Instant.now().toString(),
-                'Git-Commit': grgit.head().abbreviatedId,
-                'Git-Branch': grgit.branch.current().getName(),
+                'Git-Commit': gradleutils.gitInfo.abbreviatedId,
+                'Git-Branch': gradleutils.gitInfo.branch,
                 'Build-Number': "${System.getenv('BUILD_NUMBER')?:0}" ],
             'net/minecraftforge/accesstransformer/service/')
     attributes(['Specification-Title': 'accesstransformers',
                 'Specification-Vendor': 'Forge',
                 'Specification-Version': '1', // Currently version 1 of the accesstransformer specification
                 'Implementation-Title': project.name,
-                'Implementation-Version': "${project.version}+${System.getenv('BUILD_NUMBER')?:0}+${grgit.branch.current().getName()}.${grgit.head().abbreviatedId}",
+                'Implementation-Version': "${project.version}+${System.getenv('BUILD_NUMBER')?:0}+${gradleutils.gitInfo.branch}.${gradleutils.gitInfo.abbreviatedId}",
                 'Implementation-Vendor': 'forge',
                 'Implementation-Timestamp': java.time.Instant.now().toString(),
-                'Git-Commit': grgit.head().abbreviatedId,
-                'Git-Branch': grgit.branch.current().getName(),
+                'Git-Commit': gradleutils.gitInfo.abbreviatedId,
+                'Git-Branch': gradleutils.gitInfo.branch,
                 'Build-Number': "${System.getenv('BUILD_NUMBER')?:0}" ],
             'net/minecraftforge/accesstransformer/')
 }

--- a/build.gradle
+++ b/build.gradle
@@ -76,12 +76,13 @@ jar.manifest = manifest {
 }
 
 task testsJar(type: Jar) {
-    classifier 'testsjar'
+    archiveClassifier = 'testsjar'
     from sourceSets.testJars.output
 }
 
 task sourcesJar(type: Jar) {
-    classifier 'sources'
+    dependsOn generateGrammarSource
+    archiveClassifier = 'sources'
     from sourceSets.main.allSource
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This PR updates the buildscript to Gradle 7, removes grgit in favor of jgit, and updates ASM to 9.1. The maven has been updated along with the publish block. The Jenkinsfile has also been updated.