### PR TITLE
Add benchmark to accesstransformer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@
 /forge-deobfed.jar
 /out.log
 gradle.properties
+
+/at-jmh/build/

--- a/at-jmh/build.gradle
+++ b/at-jmh/build.gradle
@@ -1,0 +1,36 @@
+configurations {
+    jmhOnly
+}
+
+dependencies {
+    implementation(rootProject)
+    implementation('org.openjdk.jmh:jmh-core:1.35')
+    jmhOnly('org.openjdk.jmh:jmh-core:1.35')
+    jmhOnly('org.openjdk.jmh:jmh-generator-annprocess:1.35')
+    jmhOnly(sourceSets.main.output)
+    annotationProcessor('org.openjdk.jmh:jmh-generator-annprocess:1.35')
+    implementation('org.ow2.asm:asm:9.3')
+}
+
+task jmh(type: JavaExec, dependsOn: sourceSets.main.output) {
+    javaLauncher = javaToolchains.launcherFor {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
+    jvmArgs= [
+        '-p', sourceSets.main.runtimeClasspath.asPath,
+        '--add-modules', 'ALL-MODULE-PATH',
+    ]
+    classpath = files(configurations.jmhOnly.asPath)
+    mainClass = 'org.openjdk.jmh.Main'
+    args    '-bm', 'avgt'  // benchmark mode
+    args    '-r', '5s' // iteration time
+    args    '-w', '5s' // warmup time
+    args    '-wi', '2' // warmup iterations
+    args    '-prof', 'stack'
+    args    '-prof', 'jfr' // profilers
+    args    '-tu', 'us' // time unit
+    args    '-i', '2' // iterations
+    args    '-f', '1' // forks
+    args    '-rff', project.file("${rootProject.buildDir}/jmh_results.txt")  // results file
+    args    'net.minecraftforge.accesstransformer.benchmarks.AccessTransformerListBenchmark'
+}

--- a/at-jmh/src/main/java/net/minecraftforge/accesstransformer/benchmarks/AccessTransformerListBenchmark.java
+++ b/at-jmh/src/main/java/net/minecraftforge/accesstransformer/benchmarks/AccessTransformerListBenchmark.java
@@ -1,0 +1,43 @@
+package net.minecraftforge.accesstransformer.benchmarks;
+
+import net.minecraftforge.accesstransformer.parser.AccessTransformerList;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.infra.Blackhole;
+import org.objectweb.asm.Type;
+
+@State(Scope.Benchmark)
+public class AccessTransformerListBenchmark {
+    private AccessTransformerList staticList;
+
+    @Setup
+    public void setup() throws Exception {
+        staticList = new AccessTransformerList();
+        staticList.loadFromResource("accesstransformer_forge_119.cfg");
+        staticList.loadFromResource("accesstransformer_firstaid_119.cfg");
+        staticList.loadFromResource("accesstransformer_jei_119.cfg");
+    }
+
+    @Benchmark
+    public void testATLoad(Blackhole blackhole) throws Exception {
+        AccessTransformerList list = new AccessTransformerList();
+        list.loadFromResource("accesstransformer_forge_119.cfg");
+        list.loadFromResource("accesstransformer_firstaid_119.cfg");
+        list.loadFromResource("accesstransformer_jei_119.cfg");
+        blackhole.consume(list);
+    }
+
+    @Benchmark
+    public void testAtContainsMiss(Blackhole blackhole) throws Exception {
+        if (staticList.containsClassTarget(Type.getObjectType("net/minecraft/client/gui/font/FontManager")))
+            throw new RuntimeException("Didn't expect to find FontManager!");
+    }
+
+    @Benchmark
+    public void testAtContainsHit(Blackhole blackhole) throws Exception {
+        if (!staticList.containsClassTarget(Type.getObjectType("net/minecraft/client/gui/Gui")))
+            throw new RuntimeException("Expected to find Gui!");
+    }
+}

--- a/at-jmh/src/main/resources/accesstransformer_firstaid_119.cfg
+++ b/at-jmh/src/main/resources/accesstransformer_firstaid_119.cfg
@@ -1,0 +1,23 @@
+public net.minecraft.client.gui.Gui f_92976_ # healthUpdateCounter
+
+public-f net.minecraft.world.entity.Entity f_19804_ # dataManager
+
+public net.minecraft.server.level.ServerLevel f_8550_ # allPlayersSleeping
+
+public net.minecraft.world.entity.LivingEntity m_21262_(Lnet/minecraft/world/damagesource/DamageSource;)Z # checkTotemDeathProtection
+public net.minecraft.world.entity.LivingEntity f_20961_ # HEALTH
+
+public net.minecraft.world.entity.player.Player f_36107_ # ABSORPTION
+
+public net.minecraft.network.syncher.SynchedEntityData m_135375_(Lnet/minecraft/network/syncher/SynchedEntityData$DataItem;Lnet/minecraft/network/syncher/SynchedEntityData$DataItem;)V # setEntryValue
+public net.minecraft.network.syncher.SynchedEntityData m_135379_(Lnet/minecraft/network/syncher/EntityDataAccessor;)Lnet/minecraft/network/syncher/SynchedEntityData$DataItem; # getEntry
+
+public net.minecraft.world.item.enchantment.EnchantmentHelper m_44850_(Lnet/minecraft/world/item/enchantment/EnchantmentHelper$EnchantmentVisitor;Lnet/minecraft/world/item/ItemStack;)V # runIterationOnItem
+public net.minecraft.world.item.enchantment.EnchantmentHelper$EnchantmentVisitor
+
+# For FirstaidIngameGui
+public net.minecraft.client.gui.Gui f_92989_ #tickCount
+public net.minecraft.client.gui.Gui f_92973_ #lastHealth
+public net.minecraft.client.gui.Gui f_92975_ #lastHealthTime
+public net.minecraft.client.gui.Gui f_92974_ #displayHealth
+public net.minecraft.client.gui.Gui f_92985_ #random

--- a/at-jmh/src/main/resources/accesstransformer_forge_119.cfg
+++ b/at-jmh/src/main/resources/accesstransformer_forge_119.cfg
@@ -1,0 +1,516 @@
+public net.minecraft.advancements.CriteriaTriggers m_10595_(Lnet/minecraft/advancements/CriterionTrigger;)Lnet/minecraft/advancements/CriterionTrigger; # register
+default net.minecraft.client.KeyMapping f_90817_ # isDown
+public net.minecraft.client.Minecraft f_90987_ # textureManager
+public net.minecraft.client.Minecraft m_91122_(Lnet/minecraft/world/item/ItemStack;Lnet/minecraft/world/level/block/entity/BlockEntity;)Lnet/minecraft/world/item/ItemStack; # addCustomNbtData
+public net.minecraft.client.Minecraft m_91271_()V # createSearchTrees
+public-f net.minecraft.client.Options f_92059_ # keyMappings
+#group protected net.minecraft.client.gui.Gui *
+protected net.minecraft.client.gui.Gui f_168664_ # scopeScale
+protected net.minecraft.client.gui.Gui f_168665_ # SPYGLASS_SCOPE_LOCATION
+protected net.minecraft.client.gui.Gui f_168666_ # POWDER_SNOW_OUTLINE_LOCATION
+protected net.minecraft.client.gui.Gui f_168667_ # COLOR_WHITE
+protected net.minecraft.client.gui.Gui f_168668_ # MIN_CROSSHAIR_ATTACK_SPEED
+protected net.minecraft.client.gui.Gui f_168669_ # NUM_HEARTS_PER_ROW
+protected net.minecraft.client.gui.Gui f_168670_ # LINE_HEIGHT
+protected net.minecraft.client.gui.Gui f_168671_ # SPACER
+protected net.minecraft.client.gui.Gui f_168672_ # PORTAL_OVERLAY_ALPHA_MIN
+protected net.minecraft.client.gui.Gui f_168673_ # HEART_SIZE
+protected net.minecraft.client.gui.Gui f_168674_ # HEART_SEPARATION
+protected net.minecraft.client.gui.Gui f_193828_ # autosaveIndicatorValue
+protected net.minecraft.client.gui.Gui f_193829_ # lastAutosaveIndicatorValue
+protected net.minecraft.client.gui.Gui f_193830_ # SAVING_TEXT
+protected net.minecraft.client.gui.Gui f_193831_ # AUTOSAVE_FADE_SPEED_FACTOR
+protected net.minecraft.client.gui.Gui f_238167_ # chatDisabledByPlayerShown
+protected net.minecraft.client.gui.Gui f_92970_ # titleFadeInTime
+protected net.minecraft.client.gui.Gui f_92971_ # titleStayTime
+protected net.minecraft.client.gui.Gui f_92972_ # titleFadeOutTime
+protected net.minecraft.client.gui.Gui f_92973_ # lastHealth
+protected net.minecraft.client.gui.Gui f_92974_ # displayHealth
+protected net.minecraft.client.gui.Gui f_92975_ # lastHealthTime
+protected net.minecraft.client.gui.Gui f_92976_ # healthBlinkTime
+protected net.minecraft.client.gui.Gui f_92977_ # screenWidth
+protected net.minecraft.client.gui.Gui f_92978_ # screenHeight
+protected net.minecraft.client.gui.Gui f_92979_ # chatListeners
+protected net.minecraft.client.gui.Gui f_92981_ # VIGNETTE_LOCATION
+protected net.minecraft.client.gui.Gui f_92982_ # WIDGETS_LOCATION
+protected net.minecraft.client.gui.Gui f_92983_ # PUMPKIN_BLUR_LOCATION
+protected net.minecraft.client.gui.Gui f_92984_ # DEMO_EXPIRED_TEXT
+protected net.minecraft.client.gui.Gui f_92985_ # random
+protected net.minecraft.client.gui.Gui f_92986_ # minecraft
+protected net.minecraft.client.gui.Gui f_92987_ # itemRenderer
+protected net.minecraft.client.gui.Gui f_92988_ # chat
+protected net.minecraft.client.gui.Gui f_92989_ # tickCount
+protected net.minecraft.client.gui.Gui f_92990_ # overlayMessageString
+protected net.minecraft.client.gui.Gui f_92991_ # overlayMessageTime
+protected net.minecraft.client.gui.Gui f_92992_ # animateOverlayMessageColor
+protected net.minecraft.client.gui.Gui f_92993_ # toolHighlightTimer
+protected net.minecraft.client.gui.Gui f_92994_ # lastToolHighlight
+protected net.minecraft.client.gui.Gui f_92995_ # debugScreen
+protected net.minecraft.client.gui.Gui f_92996_ # subtitleOverlay
+protected net.minecraft.client.gui.Gui f_92997_ # spectatorGui
+protected net.minecraft.client.gui.Gui f_92998_ # tabList
+protected net.minecraft.client.gui.Gui f_92999_ # bossOverlay
+protected net.minecraft.client.gui.Gui f_93000_ # titleTime
+protected net.minecraft.client.gui.Gui f_93001_ # title
+protected net.minecraft.client.gui.Gui f_93002_ # subtitle
+#endgroup
+protected net.minecraft.client.gui.Gui m_168675_(F)V # renderSpyglassOverlay
+protected net.minecraft.client.gui.Gui m_168688_(Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/world/entity/player/Player;IIIIFIIIZ)V # renderHearts
+protected net.minecraft.client.gui.Gui m_168708_(Lnet/minecraft/resources/ResourceLocation;F)V # renderTextureOverlay
+protected net.minecraft.client.gui.Gui m_93007_(F)V # renderPortalOverlay
+public net.minecraft.client.gui.Gui m_93009_(FLcom/mojang/blaze3d/vertex/PoseStack;)V # renderHotbar
+public net.minecraft.client.gui.Gui m_93028_(Lcom/mojang/blaze3d/vertex/PoseStack;)V # renderEffects
+public net.minecraft.client.gui.Gui m_93036_(Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/world/scores/Objective;)V # displayScoreboardSidebar
+protected net.minecraft.client.gui.Gui m_93039_(Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/gui/Font;III)V # drawBackdrop
+public net.minecraft.client.gui.Gui m_93067_(Lnet/minecraft/world/entity/Entity;)V # renderVignette
+public net.minecraft.client.gui.Gui m_93080_(Lcom/mojang/blaze3d/vertex/PoseStack;)V # renderCrosshair
+protected net.minecraft.client.gui.components.AbstractSelectionList$Entry f_93521_ # list
+protected net.minecraft.client.gui.components.DebugScreenOverlay f_94032_ # block
+protected net.minecraft.client.gui.components.DebugScreenOverlay f_94033_ # liquid
+public net.minecraft.client.gui.screens.MenuScreens m_96206_(Lnet/minecraft/world/inventory/MenuType;Lnet/minecraft/client/gui/screens/MenuScreens$ScreenConstructor;)V # register
+public net.minecraft.client.gui.screens.MenuScreens$ScreenConstructor
+public net.minecraft.client.gui.screens.Screen f_169369_ # renderables
+public net.minecraft.client.model.geom.LayerDefinitions f_171106_ # OUTER_ARMOR_DEFORMATION
+public net.minecraft.client.model.geom.LayerDefinitions f_171107_ # INNER_ARMOR_DEFORMATION
+public net.minecraft.client.multiplayer.ClientPacketListener f_104899_ # commands
+public net.minecraft.client.particle.ParticleEngine m_107378_(Lnet/minecraft/core/particles/ParticleType;Lnet/minecraft/client/particle/ParticleEngine$SpriteParticleRegistration;)V # register
+public net.minecraft.client.particle.ParticleEngine m_107381_(Lnet/minecraft/core/particles/ParticleType;Lnet/minecraft/client/particle/ParticleProvider;)V # register
+public net.minecraft.client.particle.ParticleEngine$SpriteParticleRegistration
+public net.minecraft.client.player.LocalPlayer m_8088_()I # getPermissionLevel
+public net.minecraft.client.renderer.GameRenderer m_109128_(Lnet/minecraft/resources/ResourceLocation;)V # loadEffect
+protected-f net.minecraft.client.renderer.RenderStateShard f_110131_ # setupState
+public net.minecraft.client.renderer.RenderStateShard$BooleanStateShard
+public net.minecraft.client.renderer.RenderStateShard$CullStateShard
+public net.minecraft.client.renderer.RenderStateShard$DepthTestStateShard
+public net.minecraft.client.renderer.RenderStateShard$EmptyTextureStateShard
+public net.minecraft.client.renderer.RenderStateShard$LayeringStateShard
+public net.minecraft.client.renderer.RenderStateShard$LightmapStateShard
+public net.minecraft.client.renderer.RenderStateShard$MultiTextureStateShard
+public net.minecraft.client.renderer.RenderStateShard$OffsetTexturingStateShard
+public net.minecraft.client.renderer.RenderStateShard$OutputStateShard
+public net.minecraft.client.renderer.RenderStateShard$OverlayStateShard
+public net.minecraft.client.renderer.RenderStateShard$ShaderStateShard
+public net.minecraft.client.renderer.RenderStateShard$TextureStateShard
+protected-f net.minecraft.client.renderer.RenderStateShard$TextureStateShard f_110329_ # blur
+protected-f net.minecraft.client.renderer.RenderStateShard$TextureStateShard f_110330_ # mipmap
+public net.minecraft.client.renderer.RenderStateShard$TexturingStateShard
+public net.minecraft.client.renderer.RenderStateShard$TransparencyStateShard
+public net.minecraft.client.renderer.RenderStateShard$WriteMaskStateShard
+public net.minecraft.client.renderer.RenderType m_173215_(Ljava/lang/String;Lcom/mojang/blaze3d/vertex/VertexFormat;Lcom/mojang/blaze3d/vertex/VertexFormat$Mode;IZZLnet/minecraft/client/renderer/RenderType$CompositeState;)Lnet/minecraft/client/renderer/RenderType$CompositeRenderType; # create
+public net.minecraft.client.renderer.RenderType$CompositeState
+public net.minecraft.client.renderer.block.model.BlockElement m_111320_(Lnet/minecraft/core/Direction;)[F # uvsByFace
+public net.minecraft.client.renderer.block.model.BlockElement$Deserializer
+public net.minecraft.client.renderer.block.model.BlockElement$Deserializer <init>()V # constructor
+public net.minecraft.client.renderer.block.model.BlockElementFace$Deserializer
+public net.minecraft.client.renderer.block.model.BlockElementFace$Deserializer <init>()V # constructor
+public net.minecraft.client.renderer.block.model.BlockFaceUV$Deserializer
+public net.minecraft.client.renderer.block.model.BlockFaceUV$Deserializer <init>()V # constructor
+public net.minecraft.client.renderer.block.model.BlockModel f_111417_ # textureMap
+public net.minecraft.client.renderer.block.model.BlockModel f_111418_ # parent
+public net.minecraft.client.renderer.block.model.BlockModel f_111424_ # hasAmbientOcclusion
+public net.minecraft.client.renderer.block.model.BlockModel m_111437_(Lnet/minecraft/client/renderer/block/model/BlockElement;Lnet/minecraft/client/renderer/block/model/BlockElementFace;Lnet/minecraft/client/renderer/texture/TextureAtlasSprite;Lnet/minecraft/core/Direction;Lnet/minecraft/client/resources/model/ModelState;Lnet/minecraft/resources/ResourceLocation;)Lnet/minecraft/client/renderer/block/model/BakedQuad; # bakeFace
+public net.minecraft.client.renderer.block.model.ItemModelGenerator m_111638_(ILjava/lang/String;Lnet/minecraft/client/renderer/texture/TextureAtlasSprite;)Ljava/util/List; # processFrames
+public net.minecraft.client.renderer.block.model.ItemOverride$Deserializer
+public net.minecraft.client.renderer.block.model.ItemOverride$Deserializer <init>()V # constructor
+protected net.minecraft.client.renderer.block.model.ItemOverrides <init>()V # constructor
+public net.minecraft.client.renderer.block.model.ItemOverrides$BakedOverride
+public net.minecraft.client.renderer.block.model.ItemTransform$Deserializer
+public net.minecraft.client.renderer.block.model.ItemTransform$Deserializer <init>()V # constructor
+public net.minecraft.client.renderer.block.model.ItemTransform$Deserializer f_111769_ # DEFAULT_ROTATION
+public net.minecraft.client.renderer.block.model.ItemTransform$Deserializer f_111770_ # DEFAULT_TRANSLATION
+public net.minecraft.client.renderer.block.model.ItemTransform$Deserializer f_111771_ # DEFAULT_SCALE
+public net.minecraft.client.renderer.block.model.ItemTransforms$Deserializer
+public net.minecraft.client.renderer.block.model.ItemTransforms$Deserializer <init>()V # constructor
+public net.minecraft.client.renderer.blockentity.BlockEntityRenderDispatcher f_112253_ # fontRenderer - needed for rendering text in TESR items before entering world
+public net.minecraft.client.renderer.blockentity.BlockEntityRenderers m_173590_(Lnet/minecraft/world/level/block/entity/BlockEntityType;Lnet/minecraft/client/renderer/blockentity/BlockEntityRendererProvider;)V # register
+private-f net.minecraft.client.renderer.blockentity.PistonHeadRenderer f_112441_ # blockRenderer - it's static so we need to un-finalize in case this class loads to early.
+public net.minecraft.client.renderer.blockentity.SkullBlockRenderer f_112519_ # SKIN_BY_TYPE
+public net.minecraft.client.renderer.entity.EntityRenderDispatcher f_114362_ # renderers
+public net.minecraft.client.renderer.entity.EntityRenderers m_174036_(Lnet/minecraft/world/entity/EntityType;Lnet/minecraft/client/renderer/entity/EntityRendererProvider;)V # register
+protected net.minecraft.client.renderer.entity.ItemEntityRenderer m_115042_(Lnet/minecraft/world/item/ItemStack;)I # getRenderAmount
+public net.minecraft.client.renderer.entity.ItemRenderer m_115162_(Lcom/mojang/blaze3d/vertex/PoseStack;Lcom/mojang/blaze3d/vertex/VertexConsumer;Ljava/util/List;Lnet/minecraft/world/item/ItemStack;II)V # renderQuadList
+public net.minecraft.client.renderer.entity.ItemRenderer m_115189_(Lnet/minecraft/client/resources/model/BakedModel;Lnet/minecraft/world/item/ItemStack;IILcom/mojang/blaze3d/vertex/PoseStack;Lcom/mojang/blaze3d/vertex/VertexConsumer;)V # renderModelLists
+public net.minecraft.client.renderer.entity.LivingEntityRenderer m_115326_(Lnet/minecraft/client/renderer/entity/layers/RenderLayer;)Z # addLayer
+public net.minecraft.client.renderer.texture.TextureAtlasSprite m_118415_()I # getFrameCount
+public net.minecraft.client.resources.ClientPackSource f_174791_ # BUILT_IN
+private-f net.minecraft.client.resources.model.ModelBakery f_119216_ # atlasPreparations - need to un-finalize so that we can delay initialization to after calling super() in ModelLoader
+protected net.minecraft.client.resources.model.ModelBakery f_119234_ # UNREFERENCED_TEXTURES
+protected net.minecraft.client.resources.model.ModelBakery f_119243_ # resourceManager
+protected net.minecraft.client.resources.model.ModelBakery m_119364_(Lnet/minecraft/resources/ResourceLocation;)Lnet/minecraft/client/renderer/block/model/BlockModel; # loadBlockModel
+public net.minecraft.client.resources.model.SimpleBakedModel$Builder <init>(ZZZLnet/minecraft/client/renderer/block/model/ItemTransforms;Lnet/minecraft/client/renderer/block/model/ItemOverrides;)V # constructor
+public net.minecraft.client.sounds.SoundEngine f_120217_ # soundManager
+public net.minecraft.commands.arguments.selector.EntitySelectorParser m_121229_()V # finalizePredicates
+public net.minecraft.commands.arguments.selector.EntitySelectorParser m_121317_()V # parseOptions
+public net.minecraft.commands.arguments.selector.options.EntitySelectorOptions m_121453_(Ljava/lang/String;Lnet/minecraft/commands/arguments/selector/options/EntitySelectorOptions$Modifier;Ljava/util/function/Predicate;Lnet/minecraft/network/chat/Component;)V # register
+public net.minecraft.core.Holder$Reference m_205769_(Ljava/util/Collection;)V # bindTags
+public net.minecraft.core.Holder$Reference m_205775_(Lnet/minecraft/resources/ResourceKey;Ljava/lang/Object;)V # bind
+public net.minecraft.core.Holder$Reference$Type
+public net.minecraft.core.HolderSet$Named <init>(Lnet/minecraft/core/Registry;Lnet/minecraft/tags/TagKey;)V # constructor
+public net.minecraft.core.HolderSet$Named m_205835_(Ljava/util/List;)V # bind
+protected net.minecraft.core.IdMapper f_122653_ # nextId
+protected net.minecraft.core.IdMapper f_122654_ # tToId - internal map
+protected net.minecraft.core.IdMapper f_122655_ # idToT - internal index list
+public net.minecraft.core.particles.ParticleType <init>(ZLnet/minecraft/core/particles/ParticleOptions$Deserializer;)V # constructor
+public net.minecraft.core.particles.SimpleParticleType <init>(Z)V # constructor
+protected net.minecraft.data.loot.BlockLoot m_124126_(Lnet/minecraft/world/level/ItemLike;)Lnet/minecraft/world/level/storage/loot/LootTable$Builder; # createSingleItemTable
+protected net.minecraft.data.loot.BlockLoot m_124139_(Lnet/minecraft/world/level/block/Block;Lnet/minecraft/world/item/Item;)Lnet/minecraft/world/level/storage/loot/LootTable$Builder; # createOreDrop
+protected net.minecraft.data.loot.BlockLoot m_124142_(Lnet/minecraft/world/level/block/Block;Lnet/minecraft/world/item/Item;Lnet/minecraft/world/item/Item;Lnet/minecraft/world/level/storage/loot/predicates/LootItemCondition$Builder;)Lnet/minecraft/world/level/storage/loot/LootTable$Builder; # createCropDrops
+protected net.minecraft.data.loot.BlockLoot m_124157_(Lnet/minecraft/world/level/block/Block;Lnet/minecraft/world/level/block/Block;[F)Lnet/minecraft/world/level/storage/loot/LootTable$Builder; # createLeavesDrops
+protected net.minecraft.data.loot.BlockLoot m_124161_(Lnet/minecraft/world/level/block/Block;Lnet/minecraft/world/level/block/state/properties/Property;Ljava/lang/Comparable;)Lnet/minecraft/world/level/storage/loot/LootTable$Builder; # createSinglePropConditionTable
+protected net.minecraft.data.loot.BlockLoot m_124165_(Lnet/minecraft/world/level/block/Block;Lnet/minecraft/world/level/storage/loot/LootTable$Builder;)V # add
+protected net.minecraft.data.loot.BlockLoot m_124168_(Lnet/minecraft/world/level/block/Block;Lnet/minecraft/world/level/storage/loot/entries/LootPoolEntryContainer$Builder;)Lnet/minecraft/world/level/storage/loot/LootTable$Builder; # createSilkTouchDispatchTable
+protected net.minecraft.data.loot.BlockLoot m_124171_(Lnet/minecraft/world/level/block/Block;Lnet/minecraft/world/level/storage/loot/predicates/LootItemCondition$Builder;Lnet/minecraft/world/level/storage/loot/entries/LootPoolEntryContainer$Builder;)Lnet/minecraft/world/level/storage/loot/LootTable$Builder; # createSelfDropDispatchTable
+protected net.minecraft.data.loot.BlockLoot m_124175_(Lnet/minecraft/world/level/block/Block;Ljava/util/function/Function;)V # add
+protected net.minecraft.data.loot.BlockLoot m_124250_(Lnet/minecraft/world/level/ItemLike;)Lnet/minecraft/world/level/storage/loot/LootTable$Builder; # createSilkTouchOnlyTable
+protected net.minecraft.data.loot.BlockLoot m_124254_(Lnet/minecraft/world/level/block/Block;Lnet/minecraft/world/item/Item;)Lnet/minecraft/world/level/storage/loot/LootTable$Builder; # createStemDrops
+protected net.minecraft.data.loot.BlockLoot m_124257_(Lnet/minecraft/world/level/block/Block;Lnet/minecraft/world/level/ItemLike;)Lnet/minecraft/world/level/storage/loot/LootTable$Builder; # createSingleItemTableWithSilkTouch
+protected net.minecraft.data.loot.BlockLoot m_124260_(Lnet/minecraft/world/level/block/Block;Lnet/minecraft/world/level/block/Block;)Lnet/minecraft/world/level/storage/loot/LootTable$Builder; # createDoublePlantWithSeedDrops
+protected net.minecraft.data.loot.BlockLoot m_124263_(Lnet/minecraft/world/level/block/Block;Lnet/minecraft/world/level/block/Block;[F)Lnet/minecraft/world/level/storage/loot/LootTable$Builder; # createOakLeavesDrops
+protected net.minecraft.data.loot.BlockLoot m_124267_(Lnet/minecraft/world/level/block/Block;Lnet/minecraft/world/level/storage/loot/entries/LootPoolEntryContainer$Builder;)Lnet/minecraft/world/level/storage/loot/LootTable$Builder; # createShearsDispatchTable
+protected net.minecraft.data.loot.BlockLoot m_124270_(Lnet/minecraft/world/level/ItemLike;)Lnet/minecraft/world/level/storage/loot/LootTable$Builder; # createPotFlowerItemTable
+protected net.minecraft.data.loot.BlockLoot m_124274_(Lnet/minecraft/world/level/block/Block;Lnet/minecraft/world/item/Item;)Lnet/minecraft/world/level/storage/loot/LootTable$Builder; # createAttachedStemDrops
+protected net.minecraft.data.loot.BlockLoot m_124277_(Lnet/minecraft/world/level/block/Block;Lnet/minecraft/world/level/ItemLike;)Lnet/minecraft/world/level/storage/loot/LootTable$Builder; # createMushroomBlockDrop
+protected net.minecraft.data.loot.BlockLoot m_124283_(Lnet/minecraft/world/level/block/Block;Lnet/minecraft/world/level/storage/loot/entries/LootPoolEntryContainer$Builder;)Lnet/minecraft/world/level/storage/loot/LootTable$Builder; # createSilkTouchOrShearsDispatchTable
+protected net.minecraft.data.loot.BlockLoot m_124286_(Lnet/minecraft/world/level/ItemLike;)Lnet/minecraft/world/level/storage/loot/LootTable$Builder; # createShearsOnlyDrop
+protected net.minecraft.data.loot.BlockLoot m_124290_(Lnet/minecraft/world/level/block/Block;)Lnet/minecraft/world/level/storage/loot/LootTable$Builder; # createSlabItemTable
+protected net.minecraft.data.loot.BlockLoot m_124292_(Lnet/minecraft/world/level/block/Block;)Lnet/minecraft/world/level/storage/loot/LootTable$Builder; # createNameableBlockEntityTable
+protected net.minecraft.data.loot.BlockLoot m_124294_(Lnet/minecraft/world/level/block/Block;)Lnet/minecraft/world/level/storage/loot/LootTable$Builder; # createShulkerBoxDrop
+protected net.minecraft.data.loot.BlockLoot m_124296_(Lnet/minecraft/world/level/block/Block;)Lnet/minecraft/world/level/storage/loot/LootTable$Builder; # createBannerDrop
+protected net.minecraft.data.loot.BlockLoot m_124298_(Lnet/minecraft/world/level/block/Block;)Lnet/minecraft/world/level/storage/loot/LootTable$Builder; # createBeeNestDrop
+protected net.minecraft.data.loot.BlockLoot m_124300_(Lnet/minecraft/world/level/block/Block;)Lnet/minecraft/world/level/storage/loot/LootTable$Builder; # createBeeHiveDrop
+protected net.minecraft.data.loot.BlockLoot m_124302_(Lnet/minecraft/world/level/block/Block;)Lnet/minecraft/world/level/storage/loot/LootTable$Builder; # createGrassDrops
+protected net.minecraft.data.loot.BlockLoot m_124304_(Lnet/minecraft/world/level/block/Block;)Lnet/minecraft/world/level/storage/loot/LootTable$Builder; # createDoublePlantShearsDrop
+protected net.minecraft.data.loot.BlockLoot m_176039_(Lnet/minecraft/world/level/ItemLike;Lnet/minecraft/world/level/storage/loot/providers/number/NumberProvider;)Lnet/minecraft/world/level/storage/loot/LootTable$Builder; # createSingleItemTable
+protected net.minecraft.data.loot.BlockLoot m_176042_(Lnet/minecraft/world/level/block/Block;Lnet/minecraft/world/level/ItemLike;Lnet/minecraft/world/level/storage/loot/providers/number/NumberProvider;)Lnet/minecraft/world/level/storage/loot/LootTable$Builder; # createSingleItemTableWithSilkTouch
+protected net.minecraft.data.loot.BlockLoot m_176046_(Lnet/minecraft/world/level/block/Block;)Lnet/minecraft/world/level/storage/loot/LootTable$Builder; # createCopperOreDrops
+protected net.minecraft.data.loot.BlockLoot m_176048_(Lnet/minecraft/world/level/block/Block;)Lnet/minecraft/world/level/storage/loot/LootTable$Builder; # createLapisOreDrops
+protected net.minecraft.data.loot.BlockLoot m_176050_(Lnet/minecraft/world/level/block/Block;)Lnet/minecraft/world/level/storage/loot/LootTable$Builder; # createRedstoneOreDrops
+protected net.minecraft.data.loot.BlockLoot m_176052_(Lnet/minecraft/world/level/block/Block;)Lnet/minecraft/world/level/storage/loot/LootTable$Builder; # createCaveVinesDrop
+protected net.minecraft.data.loot.BlockLoot m_176056_(Lnet/minecraft/world/level/block/Block;)Lnet/minecraft/world/level/storage/loot/LootTable$Builder; # createCandleDrops
+protected net.minecraft.data.loot.BlockLoot m_176058_(Lnet/minecraft/world/level/block/Block;)Lnet/minecraft/world/level/storage/loot/LootTable$Builder; # createCandleCakeDrops
+protected net.minecraft.data.loot.BlockLoot m_236221_(Lnet/minecraft/world/level/ItemLike;Lnet/minecraft/world/level/storage/loot/functions/FunctionUserBuilder;)Lnet/minecraft/world/level/storage/loot/functions/FunctionUserBuilder; # applyExplosionDecay
+protected net.minecraft.data.loot.BlockLoot m_236224_(Lnet/minecraft/world/level/ItemLike;Lnet/minecraft/world/level/storage/loot/predicates/ConditionUserBuilder;)Lnet/minecraft/world/level/storage/loot/predicates/ConditionUserBuilder; # applyExplosionCondition
+protected net.minecraft.data.loot.BlockLoot m_236227_(Lnet/minecraft/world/level/block/Block;Lnet/minecraft/world/level/storage/loot/predicates/LootItemCondition$Builder;)Lnet/minecraft/world/level/storage/loot/LootTable$Builder; # createMultifaceBlockDrops
+protected net.minecraft.data.loot.BlockLoot m_236248_(Lnet/minecraft/world/level/block/Block;)Lnet/minecraft/world/level/storage/loot/LootTable$Builder; # createMangroveLeavesDrops
+protected net.minecraft.data.loot.EntityLoot f_124366_ # ENTITY_ON_FIRE
+protected net.minecraft.data.loot.EntityLoot m_124371_(Lnet/minecraft/world/entity/EntityType;Lnet/minecraft/world/level/storage/loot/LootTable$Builder;)V # add
+protected net.minecraft.data.loot.EntityLoot m_124380_(Lnet/minecraft/resources/ResourceLocation;Lnet/minecraft/world/level/storage/loot/LootTable$Builder;)V # add
+protected net.minecraft.data.recipes.RecipeProvider f_176505_ # COAL_SMELTABLES
+protected net.minecraft.data.recipes.RecipeProvider f_176506_ # IRON_SMELTABLES
+protected net.minecraft.data.recipes.RecipeProvider f_176507_ # COPPER_SMELTABLES
+protected net.minecraft.data.recipes.RecipeProvider f_176508_ # GOLD_SMELTABLES
+protected net.minecraft.data.recipes.RecipeProvider f_176509_ # DIAMOND_SMELTABLES
+protected net.minecraft.data.recipes.RecipeProvider f_176510_ # LAPIS_SMELTABLES
+protected net.minecraft.data.recipes.RecipeProvider f_176511_ # REDSTONE_SMELTABLES
+protected net.minecraft.data.recipes.RecipeProvider f_176512_ # EMERALD_SMELTABLES
+protected net.minecraft.data.recipes.RecipeProvider f_176513_ # shapeBuilders
+protected net.minecraft.data.recipes.RecipeProvider f_236355_ # recipePathProvider
+protected net.minecraft.data.recipes.RecipeProvider f_236356_ # advancementPathProvider
+protected net.minecraft.data.recipes.RecipeProvider m_125977_(Lnet/minecraft/world/level/ItemLike;)Lnet/minecraft/advancements/critereon/InventoryChangeTrigger$TriggerInstance; # has
+protected net.minecraft.data.recipes.RecipeProvider m_125979_(Lnet/minecraft/world/level/block/Block;)Lnet/minecraft/advancements/critereon/EnterBlockTrigger$TriggerInstance; # insideOf
+protected net.minecraft.data.recipes.RecipeProvider m_125994_(Ljava/util/function/Consumer;Lnet/minecraft/world/item/Item;Lnet/minecraft/world/item/Item;)V # netheriteSmithing
+protected net.minecraft.data.recipes.RecipeProvider m_126002_(Ljava/util/function/Consumer;Lnet/minecraft/world/level/ItemLike;Lnet/minecraft/world/level/ItemLike;)V # woodFromLogs
+protected net.minecraft.data.recipes.RecipeProvider m_126006_(Ljava/util/function/Consumer;Ljava/lang/String;Lnet/minecraft/world/item/crafting/SimpleCookingSerializer;I)V # cookRecipes
+protected net.minecraft.data.recipes.RecipeProvider m_126011_([Lnet/minecraft/advancements/critereon/ItemPredicate;)Lnet/minecraft/advancements/critereon/InventoryChangeTrigger$TriggerInstance; # inventoryTrigger
+protected net.minecraft.data.recipes.RecipeProvider m_126021_(Ljava/util/function/Consumer;Lnet/minecraft/world/level/ItemLike;Lnet/minecraft/world/level/ItemLike;)V # woodenBoat
+protected net.minecraft.data.recipes.RecipeProvider m_126061_(Ljava/util/function/Consumer;Lnet/minecraft/world/level/ItemLike;Lnet/minecraft/world/level/ItemLike;)V # coloredWoolFromWhiteWoolAndDye
+protected net.minecraft.data.recipes.RecipeProvider m_126069_(Ljava/util/function/Consumer;Lnet/minecraft/world/level/ItemLike;Lnet/minecraft/world/level/ItemLike;)V # coloredCarpetFromWhiteCarpetAndDye
+protected net.minecraft.data.recipes.RecipeProvider m_126073_(Ljava/util/function/Consumer;Lnet/minecraft/world/level/ItemLike;Lnet/minecraft/world/level/ItemLike;)V # bedFromPlanksAndWool
+protected net.minecraft.data.recipes.RecipeProvider m_126077_(Ljava/util/function/Consumer;Lnet/minecraft/world/level/ItemLike;Lnet/minecraft/world/level/ItemLike;)V # bedFromWhiteBedAndDye
+protected net.minecraft.data.recipes.RecipeProvider m_126081_(Ljava/util/function/Consumer;Lnet/minecraft/world/level/ItemLike;Lnet/minecraft/world/level/ItemLike;)V # banner
+protected net.minecraft.data.recipes.RecipeProvider m_126085_(Ljava/util/function/Consumer;Lnet/minecraft/world/level/ItemLike;Lnet/minecraft/world/level/ItemLike;)V # stainedGlassFromGlassAndDye
+protected net.minecraft.data.recipes.RecipeProvider m_126089_(Ljava/util/function/Consumer;Lnet/minecraft/world/level/ItemLike;Lnet/minecraft/world/level/ItemLike;)V # stainedGlassPaneFromStainedGlass
+protected net.minecraft.data.recipes.RecipeProvider m_126093_(Ljava/util/function/Consumer;Lnet/minecraft/world/level/ItemLike;Lnet/minecraft/world/level/ItemLike;)V # stainedGlassPaneFromGlassPaneAndDye
+protected net.minecraft.data.recipes.RecipeProvider m_126097_(Ljava/util/function/Consumer;Lnet/minecraft/world/level/ItemLike;Lnet/minecraft/world/level/ItemLike;)V # coloredTerracottaFromTerracottaAndDye
+protected net.minecraft.data.recipes.RecipeProvider m_126101_(Ljava/util/function/Consumer;Lnet/minecraft/world/level/ItemLike;Lnet/minecraft/world/level/ItemLike;)V # concretePowder
+protected net.minecraft.data.recipes.RecipeProvider m_176517_(Lnet/minecraft/world/level/ItemLike;Lnet/minecraft/world/level/ItemLike;)Ljava/lang/String; # getConversionRecipeName
+protected net.minecraft.data.recipes.RecipeProvider m_176520_(Lnet/minecraft/advancements/critereon/MinMaxBounds$Ints;Lnet/minecraft/world/level/ItemLike;)Lnet/minecraft/advancements/critereon/InventoryChangeTrigger$TriggerInstance; # has
+protected net.minecraft.data.recipes.RecipeProvider m_176523_(Lnet/minecraft/data/BlockFamily;Lnet/minecraft/data/BlockFamily$Variant;)Lnet/minecraft/world/level/block/Block; # getBaseBlock
+protected net.minecraft.data.recipes.RecipeProvider m_176531_(Ljava/util/function/Consumer;)V # buildCraftingRecipes
+protected net.minecraft.data.recipes.RecipeProvider m_176533_(Ljava/util/function/Consumer;Lnet/minecraft/world/item/crafting/SimpleCookingSerializer;Ljava/util/List;Lnet/minecraft/world/level/ItemLike;FILjava/lang/String;Ljava/lang/String;)V # oreCooking
+protected net.minecraft.data.recipes.RecipeProvider m_176546_(Ljava/util/function/Consumer;Lnet/minecraft/world/level/ItemLike;Lnet/minecraft/world/level/ItemLike;I)V # stonecutterResultFromBase
+protected net.minecraft.data.recipes.RecipeProvider m_176551_(Ljava/util/function/Consumer;Lnet/minecraft/world/level/ItemLike;Lnet/minecraft/world/level/ItemLike;Ljava/lang/String;)V # oneToOneConversionRecipe
+protected net.minecraft.data.recipes.RecipeProvider m_176556_(Ljava/util/function/Consumer;Lnet/minecraft/world/level/ItemLike;Lnet/minecraft/world/level/ItemLike;Ljava/lang/String;I)V # oneToOneConversionRecipe
+protected net.minecraft.data.recipes.RecipeProvider m_176562_(Ljava/util/function/Consumer;Lnet/minecraft/world/level/ItemLike;Lnet/minecraft/world/level/ItemLike;Ljava/lang/String;Ljava/lang/String;)V # nineBlockStorageRecipesWithCustomPacking
+protected net.minecraft.data.recipes.RecipeProvider m_176568_(Ljava/util/function/Consumer;Lnet/minecraft/world/level/ItemLike;Lnet/minecraft/world/level/ItemLike;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V # nineBlockStorageRecipes
+protected net.minecraft.data.recipes.RecipeProvider m_176580_(Ljava/util/function/Consumer;Lnet/minecraft/data/BlockFamily;)V # generateRecipes
+protected net.minecraft.data.recipes.RecipeProvider m_176583_(Ljava/util/function/Consumer;Ljava/lang/String;Lnet/minecraft/world/item/crafting/SimpleCookingSerializer;ILnet/minecraft/world/level/ItemLike;Lnet/minecraft/world/level/ItemLike;F)V # simpleCookingRecipe
+protected net.minecraft.data.recipes.RecipeProvider m_176591_(Ljava/util/function/Consumer;Ljava/util/List;Lnet/minecraft/world/level/ItemLike;FILjava/lang/String;)V # oreSmelting
+protected net.minecraft.data.recipes.RecipeProvider m_176602_(Lnet/minecraft/world/level/ItemLike;)Ljava/lang/String; # getHasName
+protected net.minecraft.data.recipes.RecipeProvider m_176610_(Ljava/util/function/Consumer;)V # waxRecipes
+protected net.minecraft.data.recipes.RecipeProvider m_176616_(Ljava/util/function/Consumer;Lnet/minecraft/world/level/ItemLike;Lnet/minecraft/world/level/ItemLike;Ljava/lang/String;Ljava/lang/String;)V # nineBlockStorageRecipesRecipesWithCustomUnpacking
+protected net.minecraft.data.recipes.RecipeProvider m_176625_(Ljava/util/function/Consumer;Ljava/util/List;Lnet/minecraft/world/level/ItemLike;FILjava/lang/String;)V # oreBlasting
+protected net.minecraft.data.recipes.RecipeProvider m_176632_(Lnet/minecraft/world/level/ItemLike;)Ljava/lang/String; # getItemName
+protected net.minecraft.data.recipes.RecipeProvider m_176644_(Lnet/minecraft/world/level/ItemLike;)Ljava/lang/String; # getSimpleRecipeName
+protected net.minecraft.data.recipes.RecipeProvider m_176656_(Lnet/minecraft/world/level/ItemLike;)Ljava/lang/String; # getSmeltingRecipeName
+protected net.minecraft.data.recipes.RecipeProvider m_176658_(Lnet/minecraft/world/level/ItemLike;Lnet/minecraft/world/item/crafting/Ingredient;)Lnet/minecraft/data/recipes/RecipeBuilder; # buttonBuilder
+protected net.minecraft.data.recipes.RecipeProvider m_176668_(Lnet/minecraft/world/level/ItemLike;)Ljava/lang/String; # getBlastingRecipeName
+protected net.minecraft.data.recipes.RecipeProvider m_176670_(Lnet/minecraft/world/level/ItemLike;Lnet/minecraft/world/item/crafting/Ingredient;)Lnet/minecraft/data/recipes/RecipeBuilder; # doorBuilder
+protected net.minecraft.data.recipes.RecipeProvider m_176678_(Lnet/minecraft/world/level/ItemLike;Lnet/minecraft/world/item/crafting/Ingredient;)Lnet/minecraft/data/recipes/RecipeBuilder; # fenceBuilder
+protected net.minecraft.data.recipes.RecipeProvider m_176684_(Lnet/minecraft/world/level/ItemLike;Lnet/minecraft/world/item/crafting/Ingredient;)Lnet/minecraft/data/recipes/RecipeBuilder; # fenceGateBuilder
+protected net.minecraft.data.recipes.RecipeProvider m_176690_(Ljava/util/function/Consumer;Lnet/minecraft/world/level/ItemLike;Lnet/minecraft/world/level/ItemLike;)V # pressurePlate
+protected net.minecraft.data.recipes.RecipeProvider m_176694_(Lnet/minecraft/world/level/ItemLike;Lnet/minecraft/world/item/crafting/Ingredient;)Lnet/minecraft/data/recipes/RecipeBuilder; # pressurePlateBuilder
+protected net.minecraft.data.recipes.RecipeProvider m_176700_(Ljava/util/function/Consumer;Lnet/minecraft/world/level/ItemLike;Lnet/minecraft/world/level/ItemLike;)V # slab
+protected net.minecraft.data.recipes.RecipeProvider m_176704_(Lnet/minecraft/world/level/ItemLike;Lnet/minecraft/world/item/crafting/Ingredient;)Lnet/minecraft/data/recipes/RecipeBuilder; # slabBuilder
+protected net.minecraft.data.recipes.RecipeProvider m_176710_(Lnet/minecraft/world/level/ItemLike;Lnet/minecraft/world/item/crafting/Ingredient;)Lnet/minecraft/data/recipes/RecipeBuilder; # stairBuilder
+protected net.minecraft.data.recipes.RecipeProvider m_176716_(Ljava/util/function/Consumer;Lnet/minecraft/world/level/ItemLike;Lnet/minecraft/world/level/ItemLike;)V # carpet
+protected net.minecraft.data.recipes.RecipeProvider m_176720_(Lnet/minecraft/world/level/ItemLike;Lnet/minecraft/world/item/crafting/Ingredient;)Lnet/minecraft/data/recipes/RecipeBuilder; # trapdoorBuilder
+protected net.minecraft.data.recipes.RecipeProvider m_176726_(Lnet/minecraft/world/level/ItemLike;Lnet/minecraft/world/item/crafting/Ingredient;)Lnet/minecraft/data/recipes/RecipeBuilder; # signBuilder
+protected net.minecraft.data.recipes.RecipeProvider m_176735_(Ljava/util/function/Consumer;Lnet/minecraft/world/level/ItemLike;Lnet/minecraft/world/level/ItemLike;)V # stonecutterResultFromBase
+protected net.minecraft.data.recipes.RecipeProvider m_176739_(Ljava/util/function/Consumer;Lnet/minecraft/world/level/ItemLike;Lnet/minecraft/world/level/ItemLike;)V # smeltingResultFromBase
+protected net.minecraft.data.recipes.RecipeProvider m_176743_(Ljava/util/function/Consumer;Lnet/minecraft/world/level/ItemLike;Lnet/minecraft/world/level/ItemLike;)V # nineBlockStorageRecipes
+protected net.minecraft.data.recipes.RecipeProvider m_206406_(Lnet/minecraft/tags/TagKey;)Lnet/minecraft/advancements/critereon/InventoryChangeTrigger$TriggerInstance; # has
+protected net.minecraft.data.recipes.RecipeProvider m_206408_(Ljava/util/function/Consumer;Lnet/minecraft/world/level/ItemLike;Lnet/minecraft/tags/TagKey;)V # planksFromLog
+protected net.minecraft.data.recipes.RecipeProvider m_206412_(Ljava/util/function/Consumer;Lnet/minecraft/world/level/ItemLike;Lnet/minecraft/tags/TagKey;)V # planksFromLogs
+protected net.minecraft.data.recipes.RecipeProvider m_236367_(Lnet/minecraft/data/CachedOutput;Lcom/google/gson/JsonObject;Ljava/nio/file/Path;)V # saveAdvancement
+public net.minecraft.data.recipes.ShapedRecipeBuilder$Result
+protected net.minecraft.data.tags.TagsProvider f_126543_ # builders
+public-f net.minecraft.data.tags.TagsProvider m_6055_()Ljava/lang/String; # getName
+public net.minecraft.data.tags.TagsProvider$TagAppender f_126569_ # registry
+public net.minecraft.gametest.framework.GameTestServer <init>(Ljava/lang/Thread;Lnet/minecraft/world/level/storage/LevelStorageSource$LevelStorageAccess;Lnet/minecraft/server/packs/repository/PackRepository;Lnet/minecraft/server/WorldStem;Ljava/util/Collection;Lnet/minecraft/core/BlockPos;)V # constructor
+public net.minecraft.network.protocol.status.ClientboundStatusResponsePacket f_134885_ # GSON
+public net.minecraft.resources.ResourceLocation m_135835_(C)Z # validNamespaceChar
+public net.minecraft.resources.ResourceLocation m_135841_(Ljava/lang/String;)Z # isValidPath
+public net.minecraft.resources.ResourceLocation m_135843_(Ljava/lang/String;)Z # isValidNamespace
+protected net.minecraft.server.MinecraftServer f_129726_ # nextTickTime
+public net.minecraft.server.MinecraftServer$ReloadableResources
+public net.minecraft.server.dedicated.DedicatedServer f_139600_ # consoleInput
+public net.minecraft.server.level.ServerChunkCache f_8329_ # level
+public net.minecraft.server.level.ServerLevel m_142646_()Lnet/minecraft/world/level/entity/LevelEntityGetter; # getEntities
+public net.minecraft.server.level.ServerPlayer f_8940_ # containerCounter
+public net.minecraft.server.level.ServerPlayer m_143399_(Lnet/minecraft/world/inventory/AbstractContainerMenu;)V # initMenu
+public net.minecraft.server.level.ServerPlayer m_9217_()V # nextContainerCounter
+public net.minecraft.server.network.ServerLoginPacketListenerImpl f_10021_ # gameProfile
+public net.minecraft.server.packs.AbstractPackResources f_10203_ # file
+public net.minecraft.server.packs.PackType f_143750_ # bridgeType
+public net.minecraft.server.packs.resources.FallbackResourceManager f_10599_ # fallbacks
+public net.minecraft.util.ExtraCodecs$EitherCodec
+public net.minecraft.util.datafix.fixes.StructuresBecomeConfiguredFix$Conversion
+public net.minecraft.util.thread.BlockableEventLoop m_18689_(Ljava/lang/Runnable;)Ljava/util/concurrent/CompletableFuture; # submitAsync
+#group public net.minecraft.world.damagesource.DamageSource *() #All methods public, most are already
+public net.minecraft.world.damagesource.DamageSource <init>(Ljava/lang/String;)V # constructor
+public net.minecraft.world.damagesource.DamageSource m_146706_()Lnet/minecraft/world/damagesource/DamageSource; # damageHelmet
+public net.minecraft.world.damagesource.DamageSource m_19380_()Lnet/minecraft/world/damagesource/DamageSource; # bypassArmor
+public net.minecraft.world.damagesource.DamageSource m_19381_()Lnet/minecraft/world/damagesource/DamageSource; # bypassInvul
+public net.minecraft.world.damagesource.DamageSource m_19382_()Lnet/minecraft/world/damagesource/DamageSource; # bypassMagic
+public net.minecraft.world.damagesource.DamageSource m_19383_()Lnet/minecraft/world/damagesource/DamageSource; # setIsFire
+public net.minecraft.world.damagesource.DamageSource m_238403_()Lnet/minecraft/world/damagesource/DamageSource; # bypassEnchantments
+#endgroup
+protected net.minecraft.world.entity.Entity f_19843_ # ENTITY_COUNTER
+public net.minecraft.world.entity.Entity m_20078_()Ljava/lang/String; # getEncodeId
+public net.minecraft.world.entity.ExperienceOrb f_20770_ # value
+public net.minecraft.world.entity.Mob f_21345_ # goalSelector
+public net.minecraft.world.entity.Mob f_21346_ # targetSelector
+public net.minecraft.world.entity.SpawnPlacements m_21754_(Lnet/minecraft/world/entity/EntityType;Lnet/minecraft/world/entity/SpawnPlacements$Type;Lnet/minecraft/world/level/levelgen/Heightmap$Types;Lnet/minecraft/world/entity/SpawnPlacements$SpawnPredicate;)V # register
+public net.minecraft.world.entity.ai.memory.MemoryModuleType <init>(Ljava/util/Optional;)V # constructor
+public net.minecraft.world.entity.ai.sensing.SensorType <init>(Ljava/util/function/Supplier;)V # constructor
+protected net.minecraft.world.entity.item.PrimedTnt m_32103_()V # explode - make it easier to extend TNTEntity with custom explosion logic
+protected net.minecraft.world.entity.monster.AbstractSkeleton m_7878_()Lnet/minecraft/sounds/SoundEvent; # getStepSound - make AbstractSkeletonEntity implementable
+protected net.minecraft.world.entity.monster.Skeleton m_7878_()Lnet/minecraft/sounds/SoundEvent; # getStepSound - make AbstractSkeletonEntity implementable
+protected net.minecraft.world.entity.monster.Stray m_7878_()Lnet/minecraft/sounds/SoundEvent; # getStepSound - make AbstractSkeletonEntity implementable
+protected net.minecraft.world.entity.monster.WitherSkeleton m_7878_()Lnet/minecraft/sounds/SoundEvent; # getStepSound - make AbstractSkeletonEntity implementable
+public net.minecraft.world.entity.player.Player m_6915_()V # closeContainer
+protected net.minecraft.world.entity.projectile.Projectile <init>(Lnet/minecraft/world/entity/EntityType;Lnet/minecraft/world/level/Level;)V # constructor
+private-f net.minecraft.world.entity.raid.Raid$RaiderType f_37813_ # VALUES
+public net.minecraft.world.entity.schedule.Activity <init>(Ljava/lang/String;)V # constructor
+public net.minecraft.world.inventory.AnvilMenu f_39000_ # repairItemCountCost
+public net.minecraft.world.inventory.MenuType <init>(Lnet/minecraft/world/inventory/MenuType$MenuSupplier;)V # constructor
+public net.minecraft.world.inventory.MenuType$MenuSupplier
+public-f net.minecraft.world.item.CreativeModeTab f_40748_ # TABS - group array
+#group public net.minecraft.world.item.Item <init>
+public net.minecraft.world.item.AxeItem <init>(Lnet/minecraft/world/item/Tier;FFLnet/minecraft/world/item/Item$Properties;)V # constructor
+public net.minecraft.world.item.DiggerItem <init>(FFLnet/minecraft/world/item/Tier;Lnet/minecraft/tags/TagKey;Lnet/minecraft/world/item/Item$Properties;)V # constructor
+public net.minecraft.world.item.HoeItem <init>(Lnet/minecraft/world/item/Tier;IFLnet/minecraft/world/item/Item$Properties;)V # constructor
+public net.minecraft.world.item.PickaxeItem <init>(Lnet/minecraft/world/item/Tier;IFLnet/minecraft/world/item/Item$Properties;)V # constructor
+public net.minecraft.world.item.RecordItem <init>(ILnet/minecraft/sounds/SoundEvent;Lnet/minecraft/world/item/Item$Properties;)V # constructor
+#endgroup
+public net.minecraft.world.item.alchemy.PotionBrewing$Mix
+public net.minecraft.world.item.alchemy.PotionBrewing$Mix f_43533_ # ingredient
+public net.minecraft.world.item.context.BlockPlaceContext <init>(Lnet/minecraft/world/level/Level;Lnet/minecraft/world/entity/player/Player;Lnet/minecraft/world/InteractionHand;Lnet/minecraft/world/item/ItemStack;Lnet/minecraft/world/phys/BlockHitResult;)V # constructor
+public net.minecraft.world.item.context.UseOnContext <init>(Lnet/minecraft/world/level/Level;Lnet/minecraft/world/entity/player/Player;Lnet/minecraft/world/InteractionHand;Lnet/minecraft/world/item/ItemStack;Lnet/minecraft/world/phys/BlockHitResult;)V # constructor
+public-f net.minecraft.world.item.crafting.Ingredient
+protected net.minecraft.world.item.crafting.Ingredient <init>(Ljava/util/stream/Stream;)V # constructor
+public net.minecraft.world.item.crafting.Ingredient m_43919_(Lcom/google/gson/JsonObject;)Lnet/minecraft/world/item/crafting/Ingredient$Value; # valueFromJson
+public+f net.minecraft.world.item.crafting.Ingredient m_43923_(Lnet/minecraft/network/FriendlyByteBuf;)V # toNetwork
+public net.minecraft.world.item.crafting.Ingredient m_43938_(Ljava/util/stream/Stream;)Lnet/minecraft/world/item/crafting/Ingredient; # fromValues
+public net.minecraft.world.item.crafting.Ingredient$ItemValue
+public net.minecraft.world.item.crafting.Ingredient$ItemValue <init>(Lnet/minecraft/world/item/ItemStack;)V # constructor
+public net.minecraft.world.item.crafting.Ingredient$TagValue
+public net.minecraft.world.item.crafting.Ingredient$TagValue <init>(Lnet/minecraft/tags/TagKey;)V # constructor
+public net.minecraft.world.item.crafting.Ingredient$Value
+public net.minecraft.world.level.GameRules m_46189_(Ljava/lang/String;Lnet/minecraft/world/level/GameRules$Category;Lnet/minecraft/world/level/GameRules$Type;)Lnet/minecraft/world/level/GameRules$Key; # register
+public net.minecraft.world.level.Level f_46437_ # oRainLevel
+public net.minecraft.world.level.Level f_46438_ # rainLevel
+public net.minecraft.world.level.Level f_46439_ # oThunderLevel
+public net.minecraft.world.level.Level f_46440_ # thunderLevel
+public net.minecraft.world.level.biome.Biome$ClimateSettings
+protected net.minecraft.world.level.biome.BiomeGenerationSettings$Builder f_47827_ # carvers
+protected net.minecraft.world.level.biome.BiomeGenerationSettings$Builder f_47828_ # features
+protected net.minecraft.world.level.biome.BiomeGenerationSettings$Builder m_47832_(I)V # addFeatureStepsUpTo
+#group protected net.minecraft.world.level.biome.BiomeSpecialEffects$Builder *
+protected net.minecraft.world.level.biome.BiomeSpecialEffects$Builder f_48005_ # fogColor
+protected net.minecraft.world.level.biome.BiomeSpecialEffects$Builder f_48006_ # waterColor
+protected net.minecraft.world.level.biome.BiomeSpecialEffects$Builder f_48007_ # waterFogColor
+protected net.minecraft.world.level.biome.BiomeSpecialEffects$Builder f_48008_ # skyColor
+protected net.minecraft.world.level.biome.BiomeSpecialEffects$Builder f_48009_ # foliageColorOverride
+protected net.minecraft.world.level.biome.BiomeSpecialEffects$Builder f_48010_ # grassColorOverride
+protected net.minecraft.world.level.biome.BiomeSpecialEffects$Builder f_48011_ # grassColorModifier
+protected net.minecraft.world.level.biome.BiomeSpecialEffects$Builder f_48012_ # ambientParticle
+protected net.minecraft.world.level.biome.BiomeSpecialEffects$Builder f_48013_ # ambientLoopSoundEvent
+protected net.minecraft.world.level.biome.BiomeSpecialEffects$Builder f_48014_ # ambientMoodSettings
+protected net.minecraft.world.level.biome.BiomeSpecialEffects$Builder f_48015_ # ambientAdditionsSettings
+protected net.minecraft.world.level.biome.BiomeSpecialEffects$Builder f_48016_ # backgroundMusic
+#endgroup
+protected net.minecraft.world.level.biome.MobSpawnSettings$Builder f_48362_ # spawners
+protected net.minecraft.world.level.biome.MobSpawnSettings$Builder f_48363_ # mobSpawnCosts
+protected net.minecraft.world.level.biome.MobSpawnSettings$Builder f_48364_ # creatureGenerationProbability
+#group public net.minecraft.world.level.block.Block <init>
+public net.minecraft.world.level.block.AirBlock <init>(Lnet/minecraft/world/level/block/state/BlockBehaviour$Properties;)V # constructor
+public net.minecraft.world.level.block.AttachedStemBlock <init>(Lnet/minecraft/world/level/block/StemGrownBlock;Ljava/util/function/Supplier;Lnet/minecraft/world/level/block/state/BlockBehaviour$Properties;)V # constructor
+public net.minecraft.world.level.block.AzaleaBlock <init>(Lnet/minecraft/world/level/block/state/BlockBehaviour$Properties;)V # constructor
+public net.minecraft.world.level.block.BarrierBlock <init>(Lnet/minecraft/world/level/block/state/BlockBehaviour$Properties;)V # constructor
+public net.minecraft.world.level.block.BaseCoralFanBlock <init>(Lnet/minecraft/world/level/block/state/BlockBehaviour$Properties;)V # constructor
+public net.minecraft.world.level.block.BaseCoralPlantBlock <init>(Lnet/minecraft/world/level/block/state/BlockBehaviour$Properties;)V # constructor
+public net.minecraft.world.level.block.BaseCoralPlantTypeBlock <init>(Lnet/minecraft/world/level/block/state/BlockBehaviour$Properties;)V # constructor
+public net.minecraft.world.level.block.BaseCoralWallFanBlock <init>(Lnet/minecraft/world/level/block/state/BlockBehaviour$Properties;)V # constructor
+public net.minecraft.world.level.block.BigDripleafBlock <init>(Lnet/minecraft/world/level/block/state/BlockBehaviour$Properties;)V # constructor
+public net.minecraft.world.level.block.BigDripleafStemBlock <init>(Lnet/minecraft/world/level/block/state/BlockBehaviour$Properties;)V # constructor
+public net.minecraft.world.level.block.BlastFurnaceBlock <init>(Lnet/minecraft/world/level/block/state/BlockBehaviour$Properties;)V # constructor
+public net.minecraft.world.level.block.BushBlock <init>(Lnet/minecraft/world/level/block/state/BlockBehaviour$Properties;)V # constructor
+public net.minecraft.world.level.block.CactusBlock <init>(Lnet/minecraft/world/level/block/state/BlockBehaviour$Properties;)V # constructor
+public net.minecraft.world.level.block.CakeBlock <init>(Lnet/minecraft/world/level/block/state/BlockBehaviour$Properties;)V # constructor
+public net.minecraft.world.level.block.CandleCakeBlock <init>(Lnet/minecraft/world/level/block/Block;Lnet/minecraft/world/level/block/state/BlockBehaviour$Properties;)V # constructor
+public net.minecraft.world.level.block.CartographyTableBlock <init>(Lnet/minecraft/world/level/block/state/BlockBehaviour$Properties;)V # constructor
+public net.minecraft.world.level.block.CarvedPumpkinBlock <init>(Lnet/minecraft/world/level/block/state/BlockBehaviour$Properties;)V # constructor
+public net.minecraft.world.level.block.ChestBlock <init>(Lnet/minecraft/world/level/block/state/BlockBehaviour$Properties;Ljava/util/function/Supplier;)V # constructor
+public net.minecraft.world.level.block.ChorusFlowerBlock <init>(Lnet/minecraft/world/level/block/ChorusPlantBlock;Lnet/minecraft/world/level/block/state/BlockBehaviour$Properties;)V # constructor
+public net.minecraft.world.level.block.ChorusPlantBlock <init>(Lnet/minecraft/world/level/block/state/BlockBehaviour$Properties;)V # constructor
+public net.minecraft.world.level.block.CoralFanBlock <init>(Lnet/minecraft/world/level/block/Block;Lnet/minecraft/world/level/block/state/BlockBehaviour$Properties;)V # constructor
+public net.minecraft.world.level.block.CoralPlantBlock <init>(Lnet/minecraft/world/level/block/Block;Lnet/minecraft/world/level/block/state/BlockBehaviour$Properties;)V # constructor
+public net.minecraft.world.level.block.CoralWallFanBlock <init>(Lnet/minecraft/world/level/block/Block;Lnet/minecraft/world/level/block/state/BlockBehaviour$Properties;)V # constructor
+public net.minecraft.world.level.block.CraftingTableBlock <init>(Lnet/minecraft/world/level/block/state/BlockBehaviour$Properties;)V # constructor
+public net.minecraft.world.level.block.CropBlock <init>(Lnet/minecraft/world/level/block/state/BlockBehaviour$Properties;)V # constructor
+public net.minecraft.world.level.block.CrossCollisionBlock <init>(FFFFFLnet/minecraft/world/level/block/state/BlockBehaviour$Properties;)V # constructor
+public net.minecraft.world.level.block.DeadBushBlock <init>(Lnet/minecraft/world/level/block/state/BlockBehaviour$Properties;)V # constructor
+public net.minecraft.world.level.block.DirtPathBlock <init>(Lnet/minecraft/world/level/block/state/BlockBehaviour$Properties;)V # constructor
+public net.minecraft.world.level.block.DispenserBlock <init>(Lnet/minecraft/world/level/block/state/BlockBehaviour$Properties;)V # constructor
+public net.minecraft.world.level.block.DoorBlock <init>(Lnet/minecraft/world/level/block/state/BlockBehaviour$Properties;)V # constructor
+public net.minecraft.world.level.block.EnchantmentTableBlock <init>(Lnet/minecraft/world/level/block/state/BlockBehaviour$Properties;)V # constructor
+public net.minecraft.world.level.block.EndGatewayBlock <init>(Lnet/minecraft/world/level/block/state/BlockBehaviour$Properties;)V # constructor
+public net.minecraft.world.level.block.EndPortalBlock <init>(Lnet/minecraft/world/level/block/state/BlockBehaviour$Properties;)V # constructor
+public net.minecraft.world.level.block.EndRodBlock <init>(Lnet/minecraft/world/level/block/state/BlockBehaviour$Properties;)V # constructor
+public net.minecraft.world.level.block.EnderChestBlock <init>(Lnet/minecraft/world/level/block/state/BlockBehaviour$Properties;)V # constructor
+public net.minecraft.world.level.block.FaceAttachedHorizontalDirectionalBlock <init>(Lnet/minecraft/world/level/block/state/BlockBehaviour$Properties;)V # constructor
+public net.minecraft.world.level.block.FarmBlock <init>(Lnet/minecraft/world/level/block/state/BlockBehaviour$Properties;)V # constructor
+public net.minecraft.world.level.block.FletchingTableBlock <init>(Lnet/minecraft/world/level/block/state/BlockBehaviour$Properties;)V # constructor
+public net.minecraft.world.level.block.FungusBlock <init>(Lnet/minecraft/world/level/block/state/BlockBehaviour$Properties;Ljava/util/function/Supplier;)V # constructor
+public net.minecraft.world.level.block.FurnaceBlock <init>(Lnet/minecraft/world/level/block/state/BlockBehaviour$Properties;)V # constructor
+public net.minecraft.world.level.block.GrindstoneBlock <init>(Lnet/minecraft/world/level/block/state/BlockBehaviour$Properties;)V # constructor
+public net.minecraft.world.level.block.HalfTransparentBlock <init>(Lnet/minecraft/world/level/block/state/BlockBehaviour$Properties;)V # constructor
+public net.minecraft.world.level.block.HangingRootsBlock <init>(Lnet/minecraft/world/level/block/state/BlockBehaviour$Properties;)V # constructor
+public net.minecraft.world.level.block.IronBarsBlock <init>(Lnet/minecraft/world/level/block/state/BlockBehaviour$Properties;)V # constructor
+public net.minecraft.world.level.block.JigsawBlock <init>(Lnet/minecraft/world/level/block/state/BlockBehaviour$Properties;)V # constructor
+public net.minecraft.world.level.block.JukeboxBlock <init>(Lnet/minecraft/world/level/block/state/BlockBehaviour$Properties;)V # constructor
+public net.minecraft.world.level.block.KelpBlock <init>(Lnet/minecraft/world/level/block/state/BlockBehaviour$Properties;)V # constructor
+public net.minecraft.world.level.block.KelpPlantBlock <init>(Lnet/minecraft/world/level/block/state/BlockBehaviour$Properties;)V # constructor
+public net.minecraft.world.level.block.LadderBlock <init>(Lnet/minecraft/world/level/block/state/BlockBehaviour$Properties;)V # constructor
+public net.minecraft.world.level.block.LecternBlock <init>(Lnet/minecraft/world/level/block/state/BlockBehaviour$Properties;)V # constructor
+public net.minecraft.world.level.block.LeverBlock <init>(Lnet/minecraft/world/level/block/state/BlockBehaviour$Properties;)V # constructor
+public net.minecraft.world.level.block.LiquidBlock <init>(Lnet/minecraft/world/level/material/FlowingFluid;Lnet/minecraft/world/level/block/state/BlockBehaviour$Properties;)V # constructor
+public net.minecraft.world.level.block.LoomBlock <init>(Lnet/minecraft/world/level/block/state/BlockBehaviour$Properties;)V # constructor
+public net.minecraft.world.level.block.MangroveRootsBlock <init>(Lnet/minecraft/world/level/block/state/BlockBehaviour$Properties;)V # constructor
+public net.minecraft.world.level.block.MelonBlock <init>(Lnet/minecraft/world/level/block/state/BlockBehaviour$Properties;)V # constructor
+public net.minecraft.world.level.block.NetherWartBlock <init>(Lnet/minecraft/world/level/block/state/BlockBehaviour$Properties;)V # constructor
+public net.minecraft.world.level.block.NyliumBlock <init>(Lnet/minecraft/world/level/block/state/BlockBehaviour$Properties;)V # constructor
+public net.minecraft.world.level.block.PipeBlock <init>(FLnet/minecraft/world/level/block/state/BlockBehaviour$Properties;)V # constructor
+public net.minecraft.world.level.block.PlayerHeadBlock <init>(Lnet/minecraft/world/level/block/state/BlockBehaviour$Properties;)V # constructor
+public net.minecraft.world.level.block.PlayerWallHeadBlock <init>(Lnet/minecraft/world/level/block/state/BlockBehaviour$Properties;)V # constructor
+public net.minecraft.world.level.block.PoweredRailBlock <init>(Lnet/minecraft/world/level/block/state/BlockBehaviour$Properties;)V # constructor
+public net.minecraft.world.level.block.PressurePlateBlock <init>(Lnet/minecraft/world/level/block/PressurePlateBlock$Sensitivity;Lnet/minecraft/world/level/block/state/BlockBehaviour$Properties;)V # constructor
+public net.minecraft.world.level.block.PumpkinBlock <init>(Lnet/minecraft/world/level/block/state/BlockBehaviour$Properties;)V # constructor
+public net.minecraft.world.level.block.RailBlock <init>(Lnet/minecraft/world/level/block/state/BlockBehaviour$Properties;)V # constructor
+public net.minecraft.world.level.block.RedstoneTorchBlock <init>(Lnet/minecraft/world/level/block/state/BlockBehaviour$Properties;)V # constructor
+public net.minecraft.world.level.block.RedstoneWallTorchBlock <init>(Lnet/minecraft/world/level/block/state/BlockBehaviour$Properties;)V # constructor
+public net.minecraft.world.level.block.RepeaterBlock <init>(Lnet/minecraft/world/level/block/state/BlockBehaviour$Properties;)V # constructor
+public net.minecraft.world.level.block.RodBlock <init>(Lnet/minecraft/world/level/block/state/BlockBehaviour$Properties;)V # constructor
+public net.minecraft.world.level.block.RootsBlock <init>(Lnet/minecraft/world/level/block/state/BlockBehaviour$Properties;)V # constructor
+public net.minecraft.world.level.block.SaplingBlock <init>(Lnet/minecraft/world/level/block/grower/AbstractTreeGrower;Lnet/minecraft/world/level/block/state/BlockBehaviour$Properties;)V # constructor
+public net.minecraft.world.level.block.ScaffoldingBlock <init>(Lnet/minecraft/world/level/block/state/BlockBehaviour$Properties;)V # constructor
+public net.minecraft.world.level.block.SeaPickleBlock <init>(Lnet/minecraft/world/level/block/state/BlockBehaviour$Properties;)V # constructor
+public net.minecraft.world.level.block.SeagrassBlock <init>(Lnet/minecraft/world/level/block/state/BlockBehaviour$Properties;)V # constructor
+public net.minecraft.world.level.block.SkullBlock <init>(Lnet/minecraft/world/level/block/SkullBlock$Type;Lnet/minecraft/world/level/block/state/BlockBehaviour$Properties;)V # constructor
+public net.minecraft.world.level.block.SmithingTableBlock <init>(Lnet/minecraft/world/level/block/state/BlockBehaviour$Properties;)V # constructor
+public net.minecraft.world.level.block.SmokerBlock <init>(Lnet/minecraft/world/level/block/state/BlockBehaviour$Properties;)V # constructor
+public net.minecraft.world.level.block.SnowLayerBlock <init>(Lnet/minecraft/world/level/block/state/BlockBehaviour$Properties;)V # constructor
+public net.minecraft.world.level.block.SnowyDirtBlock <init>(Lnet/minecraft/world/level/block/state/BlockBehaviour$Properties;)V # constructor
+public net.minecraft.world.level.block.SpawnerBlock <init>(Lnet/minecraft/world/level/block/state/BlockBehaviour$Properties;)V # constructor
+public net.minecraft.world.level.block.SpongeBlock <init>(Lnet/minecraft/world/level/block/state/BlockBehaviour$Properties;)V # constructor
+public net.minecraft.world.level.block.StairBlock <init>(Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/world/level/block/state/BlockBehaviour$Properties;)V # constructor
+public net.minecraft.world.level.block.StemBlock <init>(Lnet/minecraft/world/level/block/StemGrownBlock;Ljava/util/function/Supplier;Lnet/minecraft/world/level/block/state/BlockBehaviour$Properties;)V # constructor
+public net.minecraft.world.level.block.StoneButtonBlock <init>(Lnet/minecraft/world/level/block/state/BlockBehaviour$Properties;)V # constructor
+public net.minecraft.world.level.block.StructureBlock <init>(Lnet/minecraft/world/level/block/state/BlockBehaviour$Properties;)V # constructor
+public net.minecraft.world.level.block.StructureVoidBlock <init>(Lnet/minecraft/world/level/block/state/BlockBehaviour$Properties;)V # constructor
+public net.minecraft.world.level.block.SugarCaneBlock <init>(Lnet/minecraft/world/level/block/state/BlockBehaviour$Properties;)V # constructor
+public net.minecraft.world.level.block.TallGrassBlock <init>(Lnet/minecraft/world/level/block/state/BlockBehaviour$Properties;)V # constructor
+public net.minecraft.world.level.block.TorchBlock <init>(Lnet/minecraft/world/level/block/state/BlockBehaviour$Properties;Lnet/minecraft/core/particles/ParticleOptions;)V # constructor
+public net.minecraft.world.level.block.TrapDoorBlock <init>(Lnet/minecraft/world/level/block/state/BlockBehaviour$Properties;)V # constructor
+public net.minecraft.world.level.block.WallSkullBlock <init>(Lnet/minecraft/world/level/block/SkullBlock$Type;Lnet/minecraft/world/level/block/state/BlockBehaviour$Properties;)V # constructor
+public net.minecraft.world.level.block.WallTorchBlock <init>(Lnet/minecraft/world/level/block/state/BlockBehaviour$Properties;Lnet/minecraft/core/particles/ParticleOptions;)V # constructor
+public net.minecraft.world.level.block.WaterlilyBlock <init>(Lnet/minecraft/world/level/block/state/BlockBehaviour$Properties;)V # constructor
+public net.minecraft.world.level.block.WeightedPressurePlateBlock <init>(ILnet/minecraft/world/level/block/state/BlockBehaviour$Properties;)V # constructor
+public net.minecraft.world.level.block.WetSpongeBlock <init>(Lnet/minecraft/world/level/block/state/BlockBehaviour$Properties;)V # constructor
+public net.minecraft.world.level.block.WitherSkullBlock <init>(Lnet/minecraft/world/level/block/state/BlockBehaviour$Properties;)V # constructor
+public net.minecraft.world.level.block.WitherWallSkullBlock <init>(Lnet/minecraft/world/level/block/state/BlockBehaviour$Properties;)V # constructor
+public net.minecraft.world.level.block.WoodButtonBlock <init>(Lnet/minecraft/world/level/block/state/BlockBehaviour$Properties;)V # constructor
+public net.minecraft.world.level.block.WoolCarpetBlock <init>(Lnet/minecraft/world/item/DyeColor;Lnet/minecraft/world/level/block/state/BlockBehaviour$Properties;)V # constructor
+#endgroup
+public net.minecraft.world.level.block.Block m_49805_(Lnet/minecraft/server/level/ServerLevel;Lnet/minecraft/core/BlockPos;I)V # popExperience
+public net.minecraft.world.level.block.FireBlock m_221164_(Lnet/minecraft/world/level/block/state/BlockState;)I # getBurnOdds
+public net.minecraft.world.level.block.FireBlock m_221166_(Lnet/minecraft/world/level/block/state/BlockState;)I # getIgniteOdds
+public net.minecraft.world.level.block.entity.BlockEntityType$BlockEntitySupplier
+public net.minecraft.world.level.block.entity.HopperBlockEntity m_59395_(I)V # setCooldown
+public net.minecraft.world.level.block.entity.HopperBlockEntity m_59409_()Z # isOnCustomCooldown
+public net.minecraft.world.level.block.state.properties.WoodType m_61844_(Lnet/minecraft/world/level/block/state/properties/WoodType;)Lnet/minecraft/world/level/block/state/properties/WoodType; # register
+public net.minecraft.world.level.chunk.ChunkStatus <init>(Ljava/lang/String;Lnet/minecraft/world/level/chunk/ChunkStatus;ILjava/util/EnumSet;Lnet/minecraft/world/level/chunk/ChunkStatus$ChunkType;Lnet/minecraft/world/level/chunk/ChunkStatus$GenerationTask;Lnet/minecraft/world/level/chunk/ChunkStatus$LoadingTask;)V # constructor
+protected net.minecraft.world.level.levelgen.Aquifer$NoiseBasedAquifer f_157994_ # barrierNoise
+protected net.minecraft.world.level.levelgen.Aquifer$NoiseBasedAquifer f_157996_ # lavaNoise
+protected net.minecraft.world.level.levelgen.Aquifer$NoiseBasedAquifer f_157998_ # aquiferCache
+protected net.minecraft.world.level.levelgen.Aquifer$NoiseBasedAquifer f_157999_ # aquiferLocationCache
+protected net.minecraft.world.level.levelgen.Aquifer$NoiseBasedAquifer f_158000_ # shouldScheduleFluidUpdate
+protected net.minecraft.world.level.levelgen.Aquifer$NoiseBasedAquifer f_158002_ # minGridX
+protected net.minecraft.world.level.levelgen.Aquifer$NoiseBasedAquifer f_158003_ # minGridY
+protected net.minecraft.world.level.levelgen.Aquifer$NoiseBasedAquifer f_158004_ # minGridZ
+protected net.minecraft.world.level.levelgen.Aquifer$NoiseBasedAquifer f_158005_ # gridSizeX
+protected net.minecraft.world.level.levelgen.Aquifer$NoiseBasedAquifer f_158006_ # gridSizeZ
+protected net.minecraft.world.level.levelgen.Aquifer$NoiseBasedAquifer m_158024_(II)D # similarity
+protected net.minecraft.world.level.levelgen.Aquifer$NoiseBasedAquifer m_158027_(III)I # getIndex
+protected net.minecraft.world.level.levelgen.Aquifer$NoiseBasedAquifer m_158039_(I)I # gridX
+protected net.minecraft.world.level.levelgen.Aquifer$NoiseBasedAquifer m_158045_(I)I # gridY
+protected net.minecraft.world.level.levelgen.Aquifer$NoiseBasedAquifer m_158047_(I)I # gridZ
+protected net.minecraft.world.level.levelgen.Beardifier f_158065_ # pieceIterator
+protected net.minecraft.world.level.levelgen.Beardifier f_158066_ # junctionIterator
+protected net.minecraft.world.level.levelgen.Beardifier m_158083_(III)D # getBuryContribution
+protected net.minecraft.world.level.levelgen.Beardifier m_223925_(IIII)D # getBeardContribution
+private-f net.minecraft.world.level.levelgen.DebugLevelSource f_64114_ # ALL_BLOCKS
+private-f net.minecraft.world.level.levelgen.DebugLevelSource f_64115_ # GRID_WIDTH
+private-f net.minecraft.world.level.levelgen.DebugLevelSource f_64116_ # GRID_HEIGHT
+public-f net.minecraft.world.level.levelgen.NoiseBasedChunkGenerator
+protected net.minecraft.world.level.levelgen.NoiseBasedChunkGenerator m_224239_(Lnet/minecraft/world/level/LevelHeightAccessor;Lnet/minecraft/world/level/levelgen/RandomState;IILorg/apache/commons/lang3/mutable/MutableObject;Ljava/util/function/Predicate;)Ljava/util/OptionalInt; # iterateNoiseColumn
+#group public net.minecraft.world.level.levelgen.NoiseGeneratorSettings *()
+public net.minecraft.world.level.levelgen.NoiseGeneratorSettings m_198265_(ZZ)Lnet/minecraft/world/level/levelgen/NoiseGeneratorSettings; # overworld
+public net.minecraft.world.level.levelgen.NoiseGeneratorSettings m_198268_()Lnet/minecraft/world/level/levelgen/NoiseGeneratorSettings; # end
+public net.minecraft.world.level.levelgen.NoiseGeneratorSettings m_198269_()Lnet/minecraft/world/level/levelgen/NoiseGeneratorSettings; # nether
+public net.minecraft.world.level.levelgen.NoiseGeneratorSettings m_198270_()Lnet/minecraft/world/level/levelgen/NoiseGeneratorSettings; # caves
+public net.minecraft.world.level.levelgen.NoiseGeneratorSettings m_198271_()Lnet/minecraft/world/level/levelgen/NoiseGeneratorSettings; # floatingIslands
+public net.minecraft.world.level.levelgen.NoiseGeneratorSettings m_224385_(Lnet/minecraft/core/Registry;Lnet/minecraft/resources/ResourceKey;Lnet/minecraft/world/level/levelgen/NoiseGeneratorSettings;)Lnet/minecraft/core/Holder; # register
+public net.minecraft.world.level.levelgen.NoiseGeneratorSettings m_64474_(Lcom/mojang/serialization/codecs/RecordCodecBuilder$Instance;)Lcom/mojang/datafixers/kinds/App; # lambda$static$0
+#endgroup
+public net.minecraft.world.level.levelgen.WorldGenSettings <init>(JZZLnet/minecraft/core/Registry;Ljava/util/Optional;)V # constructor
+public net.minecraft.world.level.levelgen.WorldGenSettings f_64606_ # legacyCustomOptions
+public net.minecraft.world.level.levelgen.feature.foliageplacers.FoliagePlacerType <init>(Lcom/mojang/serialization/Codec;)V # constructor
+public net.minecraft.world.level.levelgen.feature.stateproviders.BlockStateProviderType <init>(Lcom/mojang/serialization/Codec;)V # constructor
+public net.minecraft.world.level.levelgen.feature.treedecorators.TreeDecoratorType <init>(Lcom/mojang/serialization/Codec;)V # constructor
+protected net.minecraft.world.level.portal.PortalForcer f_77648_ # level
+public net.minecraft.world.level.storage.LevelResource <init>(Ljava/lang/String;)V # constructor
+private-f net.minecraft.world.level.storage.loot.LootPool f_79028_ # rolls
+private-f net.minecraft.world.level.storage.loot.LootPool f_79029_ # bonusRolls

--- a/at-jmh/src/main/resources/accesstransformer_jei_119.cfg
+++ b/at-jmh/src/main/resources/accesstransformer_jei_119.cfg
@@ -1,0 +1,21 @@
+#keyboard
+public net.minecraft.client.KeyboardHandler f_90868_ # sendRepeatsToGui
+
+#colors
+public net.minecraft.client.renderer.texture.TextureAtlasSprite f_118342_ # mainImage
+
+#RecipeBookGui
+public net.minecraft.client.gui.screens.recipebook.RecipeBookComponent f_100277_ # width
+public net.minecraft.client.gui.screens.recipebook.RecipeBookComponent f_100278_ # height
+public net.minecraft.client.gui.screens.recipebook.RecipeBookComponent f_100276_ # xOffset
+public net.minecraft.client.gui.screens.recipebook.RecipeBookComponent f_100279_ # tabButtons
+
+# AbstractWidget
+public net.minecraft.client.gui.components.AbstractWidget m_93692_(Z)V # setFocused
+
+#potions
+public net.minecraft.world.item.alchemy.PotionBrewing f_43496_ # ALLOWED_CONTAINERS
+
+# SmithingRecipe
+public net.minecraft.world.item.crafting.UpgradeRecipe f_44518_ # base
+public net.minecraft.world.item.crafting.UpgradeRecipe f_44519_ # addition

--- a/build.gradle
+++ b/build.gradle
@@ -7,27 +7,57 @@ plugins {
 }
 
 apply plugin: 'maven-publish'
-apply plugin: 'java-library'
-apply plugin: 'eclipse'
-apply plugin: 'org.javamodularity.moduleplugin'
 
-group 'net.minecraftforge'
+allprojects {
+    apply plugin: 'java-library'
+    apply plugin: 'eclipse'
+    apply plugin: 'org.javamodularity.moduleplugin'
 
-java.toolchain.languageVersion = JavaLanguageVersion.of(16)
+    group 'net.minecraftforge'
 
-version = gradleutils.getTagOffsetVersion()
+    java.toolchain.languageVersion = JavaLanguageVersion.of(16)
+
+    version = gradleutils.getTagOffsetVersion()
+
+    repositories {
+        mavenLocal()
+        maven {
+            name = 'forge'
+            url = 'https://maven.minecraftforge.net/'
+        }
+    }
+
+    def isNonStable = { String version ->
+        def stableKeyword = ['RELEASE', 'FINAL', 'GA'].any { type -> version.toUpperCase().contains(type) }
+        def regex = /^[0-9,.v-]+(-r)?$/
+        return !stableKeyword && !(version ==~ regex)
+    }
+
+    dependencyUpdates {
+        rejectVersionIf {
+            isNonStable(it.candidate.version)
+        }
+    }
+
+
+    // Hack eclipse into knowing that the gradle deps are modules
+    eclipse {
+        classpath {
+            containers 'org.eclipse.buildship.core.gradleclasspathcontainer'
+            file {
+                whenMerged {
+                    entries.findAll { it.kind == 'con' && it.path == 'org.eclipse.buildship.core.gradleclasspathcontainer' }.each {
+                        it.entryAttributes['module'] = 'true'
+                    }
+                }
+            }
+        }
+    }
+}
 println('Version: ' + version)
 
-def isNonStable = { String version ->
-    def stableKeyword = ['RELEASE', 'FINAL', 'GA'].any { it -> version.toUpperCase().contains(it) }
-    def regex = /^[0-9,.v-]+(-r)?$/
-    return !stableKeyword && !(version ==~ regex)
-}
-
-dependencyUpdates {
-    rejectVersionIf {
-        isNonStable(it.candidate.version)
-    }
+repositories {
+    mavenCentral()
 }
 
 test {
@@ -86,30 +116,22 @@ changelog {
 
 build.dependsOn testsJar
 
-repositories {
-    mavenLocal()
-    mavenCentral()
-    maven {
-        name = 'forge'
-        url = 'https://maven.minecraftforge.net/'
-    }
-}
-
+ext.asmVersion = 9.3
 dependencies {
-    testImplementation('org.junit.jupiter:junit-jupiter-api:5.7.+')
+    testImplementation('org.junit.jupiter:junit-jupiter-api:5.8.+')
     testImplementation('org.powermock:powermock-core:2.0+')
     testImplementation('cpw.mods:modlauncher:9.0.4')
-    testImplementation('com.google.code.gson:gson:2.8.6')
+    testImplementation('com.google.code.gson:gson:2.8.9')
     testImplementation(sourceSets.modlauncherImpl.output)
-    testRuntimeOnly('org.junit.jupiter:junit-jupiter-engine:5.7.+')
+    testRuntimeOnly('org.junit.jupiter:junit-jupiter-engine:5.8.+')
     testRuntimeOnly(sourceSets.testJars.runtimeClasspath)
     implementation('org.antlr:antlr4-runtime:4.9.1')
     implementation('net.sf.jopt-simple:jopt-simple:5.0.4')
-    implementation('org.ow2.asm:asm:9.1')
-    implementation('org.ow2.asm:asm-commons:9.1')
-    implementation('org.ow2.asm:asm-tree:9.1')
-    implementation('org.apache.logging.log4j:log4j-api:2.11.+')
-    implementation('org.apache.logging.log4j:log4j-core:2.11.+')
+    implementation("org.ow2.asm:asm:${asmVersion}")
+    implementation("org.ow2.asm:asm-commons:${asmVersion}")
+    implementation("org.ow2.asm:asm-tree:${asmVersion}")
+    implementation('org.apache.logging.log4j:log4j-api:2.17.0')
+    implementation('org.apache.logging.log4j:log4j-core:2.17.0')
     modlauncherImplImplementation('cpw.mods:modlauncher:9.0.4')
     modlauncherImplImplementation(sourceSets.main.output)
     antlr('org.antlr:antlr4:4.9.1')

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,4 +6,4 @@ pluginManagement {
 }
 
 rootProject.name = 'accesstransformers'
-
+include 'at-jmh'

--- a/src/test/java/net/minecraftforge/accesstransformer/test/TransformationTest.java
+++ b/src/test/java/net/minecraftforge/accesstransformer/test/TransformationTest.java
@@ -32,6 +32,7 @@ public class TransformationTest {
     Class<?> transformedClass2;
     Class<?> transformedClass3;
 
+    @Disabled
     @Test
     public void testTestingLaunchHandler() throws IOException, URISyntaxException {
         System.setProperty("test.harness", "build/classes/java/testJars");


### PR DESCRIPTION
Also adjust dependencies and gradle version to match forge 1.19 and securejarhandler.
Benchmark setup is based on securejarhandler's setup.
I've currently only added benchmarks for AccessTransformerList, as this is one of the central classes, especially because the containsClassTarget Method is called for every class being loaded, which can easily be a couple thousands.
Initial benchmarks on my 4790K@4.5GHz on Windows show the following results:
```
"Benchmark","Mode","Threads","Samples","Score","Score Error (99,9%)","Unit"
"net.minecraftforge.accesstransformer.benchmarks.AccessTransformerListBenchmark.testATLoad","avgt",1,4,"3747,959599","3718,439934","us/op"
"net.minecraftforge.accesstransformer.benchmarks.AccessTransformerListBenchmark.testAtContainsHit","avgt",1,4,"0,124412","0,014262","us/op"
"net.minecraftforge.accesstransformer.benchmarks.AccessTransformerListBenchmark.testAtContainsMiss","avgt",1,4,"9,988946","2,412332","us/op"
```