### PR TITLE
Speed up AccessTransformerList

### DIFF
--- a/src/main/java/net/minecraftforge/accesstransformer/MethodTarget.java
+++ b/src/main/java/net/minecraftforge/accesstransformer/MethodTarget.java
@@ -15,8 +15,8 @@ public class MethodTarget extends Target<MethodNode> {
     public MethodTarget(final String className, final String methodName, final List<String> arguments, final String returnValue) {
         super(className);
         this.methodName = methodName;
-        this.arguments = arguments.stream().map(s->s.replaceAll("\\.", "/")).map(Type::getType).collect(Collectors.toList());
-        this.returnType = Type.getType(returnValue.replaceAll("\\.","/"));
+        this.arguments = arguments.stream().map(s->s.replace('.', '/')).map(Type::getType).collect(Collectors.toList());
+        this.returnType = Type.getType(returnValue.replace('.', '/'));
         this.targetName = methodName+'('+arguments.stream().collect(Collectors.joining())+')'+returnType;
     }
 

--- a/src/main/java/net/minecraftforge/accesstransformer/Target.java
+++ b/src/main/java/net/minecraftforge/accesstransformer/Target.java
@@ -10,7 +10,7 @@ public abstract class Target<T> {
 
     public Target(String className) {
         this.className = className;
-        this.type = Type.getType("L" + className.replaceAll("\\.", "/") + ";");
+        this.type = Type.getType("L" + className.replace('.', '/') + ";");
     }
 
     public TargetType getType() {

--- a/src/main/java/net/minecraftforge/accesstransformer/TransformerProcessor.java
+++ b/src/main/java/net/minecraftforge/accesstransformer/TransformerProcessor.java
@@ -108,7 +108,7 @@ public class TransformerProcessor {
                                     final ClassReader classReader = new ClassReader(is);
                                     final ClassNode cn = new ClassNode();
                                     classReader.accept(cn, 0);
-                                    final Type type = Type.getType('L'+cn.name.replaceAll("\\.","/")+';');
+                                    final Type type = Type.getType('L'+cn.name.replace('.', '/')+';');
                                     if (AccessTransformerEngine.INSTANCE.handlesClass(type)) {
                                         LOGGER.debug(AXFORM_MARKER,"Transforming class {}", type);
                                         AccessTransformerEngine.INSTANCE.transform(cn, type);


### PR DESCRIPTION
As said in #16 , this method is quite hot as it gets called on runtime for every class loaded.
The average time spend in this method before this patch on a miss (which should be most of the time) is ~10 microseconds, which is actually not too bad, but it can be easily improved.
This patch reduces the time spend in this method in any case to a few nanoseconds while keeping the load time roughly the same.

I guess it will not actually be noticible in most real-world cases, after doing some math I figured that it will probably save less than one second in total even in large modpacks, but I'll open this PR anyways as I already wrote the code.

Actual benchmark results for those interested (Comparable to the numbers in #16, same PC):
```
"Benchmark","Mode","Threads","Samples","Score","Score Error (99,9%)","Unit"
"net.minecraftforge.accesstransformer.benchmarks.AccessTransformerListBenchmark.testATLoad","avgt",1,4,"3759,676171","3315,141406","us/op"
"net.minecraftforge.accesstransformer.benchmarks.AccessTransformerListBenchmark.testAtContainsHit","avgt",1,4,"0,082784","0,004119","us/op"
"net.minecraftforge.accesstransformer.benchmarks.AccessTransformerListBenchmark.testAtContainsMiss","avgt",1,4,"0,026256","0,003513","us/op"
```
The second commit reduces the time to build the AT list ever so slightly, results after that:
```
"Benchmark","Mode","Threads","Samples","Score","Score Error (99,9%)","Unit"
"net.minecraftforge.accesstransformer.benchmarks.AccessTransformerListBenchmark.testATLoad","avgt",1,2,"3510,183963",NaN,"us/op"
"net.minecraftforge.accesstransformer.benchmarks.AccessTransformerListBenchmark.testAtContainsHit","avgt",1,2,"0,088348",NaN,"us/op"
"net.minecraftforge.accesstransformer.benchmarks.AccessTransformerListBenchmark.testAtContainsMiss","avgt",1,2,"0,029233",NaN,"us/op"
```