### PR TITLE
AccessTransformers Gradle Plugin

### DIFF
--- a/.github/workflows/plugin-publish.yml
+++ b/.github/workflows/plugin-publish.yml
@@ -1,0 +1,30 @@
+name: Publish Gradle Plugin
+
+on:
+  push:
+    branches: [ 'master' ]
+    paths:
+      - at-gradle/**
+      - '!.github/workflows/**'
+      - '!settings.gradle'
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    uses: MinecraftForge/SharedActions/.github/workflows/gradle.yml@v0
+    with:
+      java: 17
+      gradle_tasks: ':at-gradle:publish :at-gradle:publishPlugins'
+      artifact_name: 'accesstransformers-gradle'
+      project_path: 'at-gradle'
+    secrets:
+      DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+      PROMOTE_ARTIFACT_WEBHOOK: ${{ secrets.PROMOTE_ARTIFACT_WEBHOOK }}
+      PROMOTE_ARTIFACT_USERNAME: ${{ secrets.PROMOTE_ARTIFACT_USERNAME }}
+      PROMOTE_ARTIFACT_PASSWORD: ${{ secrets.PROMOTE_ARTIFACT_PASSWORD }}
+      MAVEN_USER: ${{ secrets.MAVEN_USER }}
+      MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
+      GRADLE_PUBLISH_KEY: ${{ secrets.GRADLE_PUBLISH_KEY }}
+      GRADLE_PUBLISH_SECRET: ${{ secrets.GRADLE_PUBLISH_SECRET }}

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,5 @@
 /forge-deobfed-new.jar
 /forge-deobfed.jar
 /out.log
-gradle.properties
 /**/logs/
 /test_results.html

--- a/.gitversion
+++ b/.gitversion
@@ -1,0 +1,3 @@
+[gradlePlugin]
+path = "at-gradle"
+tag = "gradle"

--- a/at-gradle-demo/accesstransformer.cfg
+++ b/at-gradle-demo/accesstransformer.cfg
@@ -1,0 +1,2 @@
+public net.minecraftforge.coremod.CoreModEngine LOGGER
+public-f net.minecraftforge.coremod.CoreModEngine COREMOD

--- a/at-gradle-demo/build.gradle
+++ b/at-gradle-demo/build.gradle
@@ -1,0 +1,17 @@
+// TODO [AccessTransformers][at-gradle] Finish Demo project!
+//  See rootProject's settings.gradle for includeBuild line
+
+plugins {
+    id 'java'
+    id 'net.minecraftforge.accesstransformers'
+}
+
+java.toolchain.languageVersion = JavaLanguageVersion.of(17)
+
+accessTransformers.register {
+    config = project.file('accesstransformer.cfg')
+}
+
+dependencies {
+    compileOnly accessTransformers.dep(libs.coremods)
+}

--- a/at-gradle-demo/settings.gradle
+++ b/at-gradle-demo/settings.gradle
@@ -1,0 +1,23 @@
+import org.gradle.api.initialization.resolve.RepositoriesMode
+
+pluginManagement {
+    includeBuild '../at-gradle'
+
+    repositories {
+        maven { url = 'https://maven.minecraftforge.net' }
+    }
+}
+
+rootProject.name = 'at-gradle-demo'
+
+dependencyResolutionManagement {
+    repositories {
+        maven { url = 'https://maven.minecraftforge.net' }
+    }
+
+    repositoriesMode = RepositoriesMode.FAIL_ON_PROJECT_REPOS
+
+    versionCatalogs.register('libs') {
+        library 'coremods', 'net.minecraftforge', 'coremods' version '5.2.6'
+    }
+}

--- a/at-gradle-demo/src/main/java/net/minecraftforge/debug/accesstransformers/TestClass.java
+++ b/at-gradle-demo/src/main/java/net/minecraftforge/debug/accesstransformers/TestClass.java
@@ -1,0 +1,11 @@
+package net.minecraftforge.debug.accesstransformers;
+
+import net.minecraftforge.coremod.CoreMod;
+import net.minecraftforge.coremod.CoreModEngine;
+
+public class TestClass {
+    public static void main(String[] args) {
+        System.out.println(CoreMod.COREMODLOG);
+        System.out.println(CoreModEngine.LOGGER);
+    }
+}

--- a/at-gradle/build.gradle
+++ b/at-gradle/build.gradle
@@ -1,0 +1,145 @@
+import org.gradle.util.GradleVersion
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+import io.freefair.gradle.plugins.maven.javadoc.JavadocLinkUtil
+
+plugins {
+    id 'dev.gradleplugins.java-gradle-plugin'
+    id 'idea'
+    id 'eclipse'
+    id 'maven-publish'
+    alias libs.plugins.licenser
+    alias libs.plugins.gradleutils
+    alias libs.plugins.javadoc.links
+    alias libs.plugins.plugin.publish
+    alias libs.plugins.shadow
+}
+
+final rootBuild = gradle.includedBuild('AccessTransformers')
+
+final projectDisplayName = 'AccessTransformers Gradle Plugin'
+final projectArtifactId = base.archivesName = 'accesstransformers-gradle'
+description = 'Enables Gradle projects to use AccessTransformers on dependencies with minimal hassle.'
+group = 'net.minecraftforge'
+//version = gitversion.tagOffset
+version = '1.0.0-beta.0'
+
+println "Version: $version"
+
+java.toolchain.languageVersion = JavaLanguageVersion.of 8
+
+repositories {
+    maven { url = 'https://maven.minecraftforge.net' }
+    mavenCentral()
+}
+
+dependencies {
+    // Utils
+    implementation libs.bundles.utils
+
+    // Static Analysis
+    compileOnly libs.nulls
+}
+
+// Removes local Gradle API from compileOnly. This is a workaround for bugged plugins.
+// TODO [GradleUtils][GradleAPI] Remove this once they are fixed.
+// Publish Plugin: https://github.com/gradle/plugin-portal-requests/issues/260
+// Shadow:         https://github.com/GradleUp/shadow/pull/1422
+afterEvaluate { project ->
+    project.configurations.named(JavaPlugin.COMPILE_ONLY_CONFIGURATION_NAME) { compileOnly ->
+        compileOnly.dependencies.remove project.dependencies.gradleApi()
+    }
+}
+
+license {
+    header = new File(rootBuild.projectDir, '/LICENSE-header.txt')
+    newLine = false
+    exclude '**/*.properties'
+}
+
+tasks.named('jar', Jar) {
+    archiveClassifier = 'thin'
+}
+
+tasks.named('shadowJar', ShadowJar) {
+    enableRelocation = true
+    archiveClassifier = null
+    relocationPrefix = 'net.minecraftforge.accesstransformers.gradle.shadow'
+}
+
+tasks.withType(Javadoc).configureEach {
+    javadocTool = javaToolchains.javadocToolFor { languageVersion = JavaLanguageVersion.of 23 }
+
+    options { StandardJavadocDocletOptions options ->
+        options.links(
+            // Manually included here, since the one at javadoc.io is ass
+            JavadocLinkUtil.getGradleApiLink(GradleVersion.version(libs.versions.gradle.get()))
+        )
+
+        options.windowTitle = projectDisplayName + project.version
+        options.tags 'apiNote:a:API Note:', 'implNote:a:Implementation Note:'
+    }
+}
+
+/*
+changelog {
+    fromBase()
+    publishAll = false
+}
+ */
+
+gradlePlugin {
+    website.set gitversion.url
+    vcsUrl.set gitversion.url + '.git'
+
+    compatibility {
+        minimumGradleVersion = libs.versions.gradle.get()
+    }
+
+    java {
+        withSourcesJar()
+        withJavadocJar()
+    }
+
+    plugins.register('accesstransformers') {
+        id = 'net.minecraftforge.accesstransformers'
+        implementationClass = 'net.minecraftforge.accesstransformers.gradle.AccessTransformersPlugin'
+        displayName = projectDisplayName
+        description = project.description
+        tags = ['minecraftforge']
+    }
+}
+
+publishing {
+    publications.register('pluginMaven', MavenPublication) {
+        artifactId = projectArtifactId
+
+        //changelog.publish it
+
+        pom { pom ->
+            name = projectDisplayName
+            description = project.description
+
+            gradleutils.pom.setGitHubDetails pom
+
+            licenses {
+                license gradleutils.pom.licenses.LGPLv2_1
+            }
+
+            developers {
+                developer gradleutils.pom.developers.Jonathing
+            }
+        }
+    }
+
+    repositories {
+        maven gradleutils.getPublishingForgeMaven(new File(rootBuild.projectDir, 'repo'))
+
+        maven {
+            name = 'ModdingLegacyMaven'
+            url = 'https://maven.moddinglegacy.com/repository/modding-legacy/'
+            credentials PasswordCredentials
+        }
+    }
+}
+
+idea.module { downloadSources = downloadJavadoc = true }

--- a/at-gradle/gradle.properties
+++ b/at-gradle/gradle.properties
@@ -1,0 +1,8 @@
+org.gradle.caching=true
+#org.gradle.parallel=true
+#org.gradle.configureondemand=true
+
+#org.gradle.configuration-cache=true
+#org.gradle.configuration-cache.parallel=true
+
+systemProp.org.gradle.unsafe.suppress-gradle-api=true

--- a/at-gradle/settings.gradle
+++ b/at-gradle/settings.gradle
@@ -1,0 +1,36 @@
+import org.gradle.api.initialization.resolve.RepositoriesMode
+
+plugins {
+    id 'dev.gradleplugins.gradle-plugin-development' version '1.9.0'
+    id 'org.gradle.toolchains.foojay-resolver-convention' version '0.10.0'
+}
+
+rootProject.name = 'at-gradle'
+
+includeBuild '..'
+
+dependencyResolutionManagement {
+    // Repositories are located in build.gradle for this project
+    // dev.gradleplugins.groovy-gradle-plugin is bugged and force adds repositories on the project
+    // so, we can't declare the repositories in here
+    repositoriesMode = RepositoriesMode.PREFER_PROJECT
+
+    versionCatalogs.register('libs') {
+        plugin 'licenser', 'net.minecraftforge.licenser' version '1.2.0'
+        plugin 'gradleutils', 'net.minecraftforge.gradleutils' version '2.6.0'
+        plugin 'javadoc-links', 'io.freefair.javadoc-links' version '8.13.1'
+        plugin 'plugin-publish', 'com.gradle.plugin-publish' version '1.3.1'
+        plugin 'shadow', 'com.gradleup.shadow' version '9.0.0-beta13'
+
+        // Gradle API
+        version 'gradle', '7.3'
+
+        // Utils
+        library 'utils-hash',     'net.minecraftforge', 'hash-utils'     version '0.1.9'
+        library 'utils-download', 'net.minecraftforge', 'download-utils' version '0.3.1'
+        bundle 'utils', ['utils-hash', 'utils-download']
+
+        // Static Analysis
+        library 'nulls', 'org.jetbrains', 'annotations' version '26.0.2'
+    }
+}

--- a/at-gradle/src/main/java/net/minecraftforge/accesstransformers/gradle/AccessTransformersContainer.java
+++ b/at-gradle/src/main/java/net/minecraftforge/accesstransformers/gradle/AccessTransformersContainer.java
@@ -1,0 +1,375 @@
+/*
+ * Copyright (c) Forge Development LLC
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+package net.minecraftforge.accesstransformers.gradle;
+
+import groovy.lang.Closure;
+import groovy.lang.DelegatesTo;
+import groovy.transform.stc.ClosureParams;
+import groovy.transform.stc.SimpleType;
+import org.gradle.api.Action;
+import org.gradle.api.Project;
+import org.gradle.api.artifacts.Dependency;
+import org.gradle.api.artifacts.dsl.DependencyHandler;
+import org.gradle.api.attributes.Attribute;
+import org.gradle.api.file.FileCollection;
+import org.gradle.api.file.RegularFile;
+import org.gradle.api.provider.Provider;
+import org.gradle.api.provider.ProviderConvertible;
+import org.gradle.jvm.toolchain.JavaLauncher;
+import org.jetbrains.annotations.ApiStatus;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.function.Function;
+
+/// Represents a container of dependencies that will be access transformed.
+///
+/// Containers are created with [AccessTransformersExtension#register(Attribute, Action)]. Dependencies can be added
+/// using [#dep(Object, Closure)].
+///
+/// @apiNote This interface is effectively sealed and [must not be extended][ApiStatus.NonExtendable].
+/// @see AccessTransformersExtension
+@SuppressWarnings("UnstableApiUsage") // ProviderConvertible<?> stabilized in Gradle 8
+@ApiStatus.NonExtendable // Sealed types were not added until Java 15
+public interface AccessTransformersContainer {
+    /// Registers a new container using the given attribute and options.
+    ///
+    /// @param attribute The boolean attribute to use for this container
+    /// @param options   The options to apply
+    /// @return The registered container
+    /// @see AccessTransformersContainer.Options
+    static AccessTransformersContainer register(Project project, Attribute<Boolean> attribute, Action<? super AccessTransformersContainer.Options> options) {
+        return register(project, attribute, Closures.action(AccessTransformersContainer.class, options));
+    }
+
+    /// Registers a new container using the given attribute and options.
+    ///
+    /// @param attribute The boolean attribute to use for this container
+    /// @param options   The options to apply
+    /// @return The registered container
+    /// @see AccessTransformersContainer.Options
+    @SuppressWarnings("rawtypes") // public-facing closure
+    static AccessTransformersContainer register(
+        Project project,
+        Attribute<Boolean> attribute,
+        @DelegatesTo(value = AccessTransformersContainer.Options.class, strategy = Closure.DELEGATE_FIRST)
+        @ClosureParams(value = SimpleType.class, options = "net.minecraftforge.accesstransformers.gradle.AccessTransformersContainer.Options")
+        Closure options
+    ) {
+        return new AccessTransformersContainerImpl(project, attribute, options);
+    }
+
+    Attribute<Boolean> getAttribute();
+
+    @SuppressWarnings("rawtypes") // public-facing closure
+    void options(
+        @DelegatesTo(value = AccessTransformersContainer.Options.class, strategy = Closure.DELEGATE_FIRST)
+        @ClosureParams(value = SimpleType.class, options = "net.minecraftforge.accesstransformers.gradle.AccessTransformersContainer.Options")
+        Closure closure
+    );
+
+    default void options(Action<? super AccessTransformersContainer.Options> action) {
+        this.options(Closures.action(this, action));
+    }
+
+    /// Queues the given dependency to be transformed by AccessTransformers.
+    ///
+    /// @param dependencyNotation The dependency (notation)
+    /// @param closure            A configuring closure for the dependency
+    @SuppressWarnings("rawtypes") // public-facing closure
+    Dependency dep(
+        Object dependencyNotation,
+        @DelegatesTo(Dependency.class)
+        @ClosureParams(value = SimpleType.class, options = "org.gradle.api.artifacts.Dependency")
+        Closure closure
+    );
+
+    /// Queues the given dependency to be transformed by AccessTransformers.
+    ///
+    /// @param dependencyNotation The dependency (notation)
+    /// @param action             A configuring action for the dependency
+    default Dependency dep(Object dependencyNotation, Action<? super Dependency> action) {
+        return this.dep(dependencyNotation, Closures.action(this, action));
+    }
+
+    /// Queues the given dependency to be transformed by AccessTransformers.
+    ///
+    /// @param dependencyNotation The dependency (notation)
+    default Dependency dep(Object dependencyNotation) {
+        return this.dep(dependencyNotation, Closures.empty(this));
+    }
+
+    /// Queues the given dependency to be transformed by AccessTransformers.
+    ///
+    /// @param dependencyNotation The dependency (notation)
+    /// @param closure            A configuring closure for the dependency
+    @SuppressWarnings("rawtypes") // public-facing closure
+    default Dependency dep(
+        Provider<?> dependencyNotation,
+        @DelegatesTo(Dependency.class)
+        @ClosureParams(value = SimpleType.class, options = "org.gradle.api.artifacts.Dependency")
+        Closure closure
+    ) {
+        return this.dep(dependencyNotation.get(), closure);
+    }
+
+    /// Queues the given dependency to be transformed by AccessTransformers.
+    ///
+    /// @param dependencyNotation The dependency (notation)
+    /// @param action             A configuring action for the dependency
+    default Dependency dep(Provider<?> dependencyNotation, Action<? super Dependency> action) {
+        return this.dep(dependencyNotation, Closures.action(this, action));
+    }
+
+    /// Queues the given dependency to be transformed by AccessTransformers.
+    ///
+    /// @param dependencyNotation The dependency (notation)
+    default Dependency dep(Provider<?> dependencyNotation) {
+        return this.dep(dependencyNotation, Closures.empty(this));
+    }
+
+    /// Queues the given dependency to be transformed by AccessTransformers.
+    ///
+    /// @param dependencyNotation The dependency (notation)
+    /// @param closure            A configuring closure for the dependency
+    @SuppressWarnings("rawtypes") // public-facing closure
+    default Dependency dep(
+        ProviderConvertible<?> dependencyNotation,
+        @DelegatesTo(Dependency.class)
+        @ClosureParams(value = SimpleType.class, options = "org.gradle.api.artifacts.Dependency")
+        Closure closure
+    ) {
+        return this.dep(dependencyNotation.asProvider(), closure);
+    }
+
+    /// Queues the given dependency to be transformed by AccessTransformers.
+    ///
+    /// @param dependencyNotation The dependency (notation)
+    /// @param action             A configuring action for the dependency
+    default Dependency dep(ProviderConvertible<?> dependencyNotation, Action<? super Dependency> action) {
+        return this.dep(dependencyNotation, Closures.action(this, action));
+    }
+
+    /// Queues the given dependency to be transformed by AccessTransformers.
+    ///
+    /// @param dependencyNotation The dependency (notation)
+    default Dependency dep(ProviderConvertible<?> dependencyNotation) {
+        return this.dep(dependencyNotation, Closures.empty(this));
+    }
+
+    /// When initially registering an AccessTransformers container, the consumer must define key information regarding
+    /// how AccessTransformers will be used. This interface is used to define that information.
+    @ApiStatus.NonExtendable
+    interface Options {
+        /// Sets the configuration to use as the classpath for AccessTransformers.
+        ///
+        /// @param files The file collection to use
+        void setClasspath(FileCollection files);
+
+        void setClasspath(
+            @DelegatesTo(value = DependencyHandler.class, strategy = Closure.DELEGATE_FIRST)
+            @ClosureParams(value = SimpleType.class, options = "org.gradle.api.artifacts.dsl.DependencyHandler")
+            Closure<? extends Dependency> closure
+        );
+
+        /// Sets the dependency to use as the classpath for AccessTransformers.
+        ///
+        /// @param dependency The dependency to use
+        default void setClasspath(Function<? super DependencyHandler, ? extends Dependency> dependency) {
+            this.setClasspath(Closures.function(this, dependency));
+        }
+
+        /// Sets the dependency to use as the classpath for AccessTransformers.
+        ///
+        /// @param dependencyNotation The dependency (notation) to use
+        /// @param closure            A configuring closure for the dependency
+        @SuppressWarnings("rawtypes")
+        default void setClasspath(
+            Object dependencyNotation,
+            @DelegatesTo(Dependency.class)
+            @ClosureParams(value = SimpleType.class, options = "org.gradle.api.artifacts.Dependency")
+            Closure closure
+        ) {
+            this.setClasspath(dependencies -> dependencies.create(dependencyNotation, closure));
+        }
+
+        /// Sets the dependency to use as the classpath for AccessTransformers.
+        ///
+        /// @param dependencyNotation The dependency (notation) to use
+        /// @param action             A configuring action for the dependency
+        default void setClasspath(
+            Object dependencyNotation,
+            Action<? super Dependency> action
+        ) {
+            this.setClasspath(dependencyNotation, Closures.action(this, action));
+        }
+
+        /// Sets the dependency to use as the classpath for AccessTransformers.
+        ///
+        /// @param dependencyNotation The dependency (notation) to use
+        default void setClasspath(Object dependencyNotation) {
+            this.setClasspath(dependencyNotation, Closures.empty(this));
+        }
+
+        /// Sets the dependency to use as the classpath for AccessTransformers.
+        ///
+        /// @param dependencyNotation The dependency (notation) to use
+        /// @param closure            A configuring closure for the dependency
+        @SuppressWarnings("rawtypes")
+        default void setClasspath(
+            Provider<?> dependencyNotation,
+            @DelegatesTo(Dependency.class)
+            @ClosureParams(value = SimpleType.class, options = "org.gradle.api.artifacts.Dependency")
+            Closure closure
+        ) {
+            this.setClasspath(dependencyNotation.get(), closure);
+        }
+
+        /// Sets the dependency to use as the classpath for AccessTransformers.
+        ///
+        /// @param dependencyNotation The dependency (notation) to use
+        /// @param action             A configuring action for the dependency
+        default void setClasspath(
+            Provider<?> dependencyNotation,
+            Action<? super Dependency> action
+        ) {
+            this.setClasspath(dependencyNotation, Closures.action(this, action));
+        }
+
+        /// Sets the dependency to use as the classpath for AccessTransformers.
+        ///
+        /// @param dependencyNotation The dependency (notation) to use
+        default void setClasspath(Provider<?> dependencyNotation) {
+            this.setClasspath(dependencyNotation, Closures.empty(this));
+        }
+
+        /// Sets the dependency to use as the classpath for AccessTransformers.
+        ///
+        /// @param dependencyNotation The dependency (notation) to use
+        /// @param closure            A configuring closure for the dependency
+        @SuppressWarnings("rawtypes")
+        default void setClasspath(
+            ProviderConvertible<?> dependencyNotation,
+            @DelegatesTo(Dependency.class)
+            @ClosureParams(value = SimpleType.class, options = "org.gradle.api.artifacts.Dependency")
+            Closure closure
+        ) {
+            this.setClasspath(dependencyNotation.asProvider(), closure);
+        }
+
+        /// Sets the dependency to use as the classpath for AccessTransformers.
+        ///
+        /// @param dependencyNotation The dependency (notation) to use
+        /// @param action             A configuring action for the dependency
+        default void setClasspath(
+            ProviderConvertible<?> dependencyNotation,
+            Action<? super Dependency> action
+        ) {
+            this.setClasspath(dependencyNotation, Closures.action(this, action));
+        }
+
+        /// Sets the dependency to use as the classpath for AccessTransformers.
+        ///
+        /// @param dependencyNotation The dependency (notation) to use
+        default void setClasspath(ProviderConvertible<?> dependencyNotation) {
+            this.setClasspath(dependencyNotation, Closures.empty(this));
+        }
+
+        /// Sets the main class to invoke when running AccessTransformers.
+        ///
+        /// @param mainClass The main class to use
+        /// @apiNote This is *not required* if the given [classpath][#setClasspath(FileCollection)] is a single
+        /// executable jar.
+        void setMainClass(Provider<String> mainClass);
+
+        /// Sets the main class to invoke when running AccessTransformers.
+        ///
+        /// @param mainClass The main class to use
+        /// @apiNote This is *not required* if the given [classpath][#setClasspath(FileCollection)] is a single
+        /// executable jar.
+        void setMainClass(String mainClass);
+
+        /// Sets the Java launcher to use to run AccessTransformers.
+        ///
+        /// This can be easily acquired using [Java toolchains][org.gradle.jvm.toolchain.JavaToolchainService].
+        ///
+        /// @param javaLauncher The Java launcher to use
+        /// @see org.gradle.jvm.toolchain.JavaToolchainService#launcherFor(Action)
+        void setJavaLauncher(Provider<? extends JavaLauncher> javaLauncher);
+
+        /// Sets the Java launcher to use to run AccessTransformers.
+        ///
+        /// This can be easily acquired using [Java toolchains][org.gradle.jvm.toolchain.JavaToolchainService].
+        ///
+        /// @param javaLauncher The Java launcher to use
+        /// @apiNote This method exists in case consumers have an eagerly processed `JavaLauncher` object. It is
+        /// recommended to use [#setJavaLauncher(Provider)] instead.
+        /// @see org.gradle.jvm.toolchain.JavaToolchainService#launcherFor(Action)
+        void setJavaLauncher(JavaLauncher javaLauncher);
+
+        /// Sets the arguments to use when running AccessTransformers.
+        ///
+        /// When processed by the transform action, these arguments will have specific tokens in them replaced.
+        ///
+        /// - `{inJar}` - The input jar
+        /// - `{atFile}` - The AccessTransformers configuration file
+        /// - `{outJar}` - The output jar
+        /// - `{logFile}` - The log file
+        ///
+        /// @param args The arguments to use
+        void setArgs(Provider<? extends Iterable<String>> args);
+
+        /// Sets the arguments to use when running AccessTransformers.
+        ///
+        /// When processed by the transform action, these arguments will have specific tokens in them replaced.
+        ///
+        /// - `{inJar}` - The input jar
+        /// - `{atFile}` - The AccessTransformers configuration file
+        /// - `{outJar}` - The output jar
+        /// - `{logFile}` - The log file
+        ///
+        /// @param args The arguments to use
+        void setArgs(Iterable<String> args);
+
+        /// Sets the arguments to use when running AccessTransformers.
+        ///
+        /// When processed by the transform action, these arguments will have specific tokens in them replaced.
+        ///
+        /// - `{inJar}` - The input jar
+        /// - `{atFile}` - The AccessTransformers configuration file
+        /// - `{outJar}` - The output jar
+        /// - `{logFile}` - The log file
+        ///
+        /// @param args The arguments to use
+        default void setArgs(String... args) {
+            this.setArgs(Arrays.asList(args));
+        }
+
+        /// Sets the AccessTransformer configuration to use.
+        ///
+        /// If the given provider does not provide a [file][File] or [regular file][RegularFile], the result will be
+        /// resolved using [org.gradle.api.Project#file(Object)], similarly to [#setConfig(Object)].
+        ///
+        /// @param configFile The configuration file to use
+        void setConfig(Provider<?> configFile);
+
+        /// Sets the AccessTransformer configuration to use.
+        ///
+        /// @param configFile The configuration file to use
+        void setConfig(RegularFile configFile);
+
+        /// Sets the AccessTransformer configuration to use.
+        ///
+        /// @param configFile The configuration file to use
+        void setConfig(File configFile);
+
+        /// Sets the AccessTransformer configuration to use.
+        ///
+        /// The given object is resolved using [org.gradle.api.Project#file(Object)].
+        ///
+        /// @param configFile The configuration file to use
+        void setConfig(Object configFile);
+    }
+}

--- a/at-gradle/src/main/java/net/minecraftforge/accesstransformers/gradle/AccessTransformersContainerImpl.java
+++ b/at-gradle/src/main/java/net/minecraftforge/accesstransformers/gradle/AccessTransformersContainerImpl.java
@@ -1,0 +1,258 @@
+package net.minecraftforge.accesstransformers.gradle;
+
+import groovy.lang.Closure;
+import groovy.lang.DelegatesTo;
+import groovy.transform.stc.ClosureParams;
+import groovy.transform.stc.SimpleType;
+import org.gradle.api.PathValidation;
+import org.gradle.api.Project;
+import org.gradle.api.artifacts.Dependency;
+import org.gradle.api.artifacts.dsl.DependencyHandler;
+import org.gradle.api.artifacts.type.ArtifactTypeDefinition;
+import org.gradle.api.attributes.Attribute;
+import org.gradle.api.attributes.AttributeContainer;
+import org.gradle.api.attributes.HasConfigurableAttributes;
+import org.gradle.api.file.FileCollection;
+import org.gradle.api.file.FileSystemLocation;
+import org.gradle.api.file.RegularFile;
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.plugins.JavaPluginExtension;
+import org.gradle.api.provider.ListProperty;
+import org.gradle.api.provider.Property;
+import org.gradle.api.provider.Provider;
+import org.gradle.api.provider.ProviderFactory;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.InputFile;
+import org.gradle.api.tasks.InputFiles;
+import org.gradle.api.tasks.Optional;
+import org.gradle.jvm.toolchain.JavaLanguageVersion;
+import org.gradle.jvm.toolchain.JavaLauncher;
+import org.gradle.jvm.toolchain.JavaToolchainService;
+import org.gradle.jvm.toolchain.JavaToolchainSpec;
+
+import javax.inject.Inject;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Objects;
+
+import static net.minecraftforge.accesstransformers.gradle.AccessTransformersPlugin.LOGGER;
+
+final class AccessTransformersContainerImpl implements AccessTransformersContainer {
+    private final Project project;
+    private final Attribute<Boolean> attribute;
+    private final AccessTransformersContainerImpl.OptionsImpl options;
+
+    @SuppressWarnings("rawtypes") // public-facing closure
+    AccessTransformersContainerImpl(
+        Project project,
+        Attribute<Boolean> attribute,
+        @DelegatesTo(value = AccessTransformersContainer.Options.class, strategy = Closure.DELEGATE_FIRST)
+        @ClosureParams(value = SimpleType.class, options = "net.minecraftforge.accesstransformers.gradle.AccessTransformersContainer.Options")
+        Closure options
+    ) {
+        this.attribute = Objects.requireNonNull(attribute);
+        Closures.invoke(this.options = new AccessTransformersContainerImpl.OptionsImpl(this.project = project), options);
+
+        project.afterEvaluate(this::finish);
+    }
+
+    private void finish(Project project) {
+        project.dependencies(Closures.<DependencyHandler>consumer(this, dependencies -> {
+            dependencies.attributesSchema(attributesSchema -> {
+                if (attributesSchema.hasAttribute(this.attribute))
+                    throw new IllegalStateException("Another project in this build is already using this attribute for AccessTransformers: " + this.attribute);
+
+                attributesSchema.attribute(this.attribute);
+            });
+
+            dependencies.getArtifactTypes().named(
+                ArtifactTypeDefinition.JAR_TYPE,
+                type -> type.getAttributes().attribute(this.attribute, false)
+            );
+
+            dependencies.registerTransform(ArtifactAccessTransformer.class, spec -> {
+                spec.parameters(parameters -> {
+                    parameters.getClasspath().set(this.options.classpath);
+                    parameters.getMainClass().set(this.options.mainClass);
+                    parameters.getJavaLauncher().set(this.options.javaLauncher);
+                    parameters.getArgs().set(this.options.args);
+                    parameters.getConfig().set(this.options.config);
+
+                    parameters.getCachesDir().convention(project.getLayout().getBuildDirectory().dir(Constants.CACHES_PATH_LOCAL).map(dir -> {
+                        Path path = dir.getAsFile().toPath();
+                        try {
+                            Files.createDirectories(path);
+                        } catch (IOException e) {
+                            throw new RuntimeException("Failed to create directory: " + path.toAbsolutePath(), e);
+                        }
+
+                        return dir;
+                    }));
+                });
+
+                this.setAttributes(spec.getFrom(), false);
+                this.setAttributes(spec.getTo(), true);
+            });
+        }));
+    }
+
+    @SuppressWarnings("UnstableApiUsage") // ArtifactTypeDefinition#ARTIFACT_TYPE_ATTRIBUTE (stabilized in Gradle 8)
+    private void setAttributes(AttributeContainer attributes, boolean value) {
+        attributes.attribute(ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE, ArtifactTypeDefinition.JAR_TYPE)
+                  .attribute(this.attribute, value);
+    }
+
+    @Override
+    public Attribute<Boolean> getAttribute() {
+        return this.attribute;
+    }
+
+    @Override
+    @SuppressWarnings("rawtypes") // public-facing closure
+    public void options(
+        @DelegatesTo(value = AccessTransformersContainer.Options.class, strategy = Closure.DELEGATE_FIRST)
+        @ClosureParams(value = SimpleType.class, options = "net.minecraftforge.accesstransformers.gradle.AccessTransformersContainer.Options")
+        Closure closure
+    ) {
+        Closures.invoke(this.options, closure);
+    }
+
+    @Override
+    @SuppressWarnings("rawtypes") // public-facing closure
+    public Dependency dep(
+        Object dependencyNotation,
+        @DelegatesTo(Dependency.class)
+        @ClosureParams(value = SimpleType.class, options = "org.gradle.api.artifacts.Dependency")
+        Closure closure
+    ) {
+        Dependency dependency = project.getDependencies().create(dependencyNotation, closure);
+        if (dependency instanceof HasConfigurableAttributes<?>) {
+            ((HasConfigurableAttributes<?>) dependency).attributes(a -> a.attribute(this.attribute, true));
+        } else {
+            LOGGER.warn("Cannot apply access transformer attribute to dependency: {} ({})", dependency, dependency.getClass().getName());
+        }
+        return dependency;
+    }
+
+    private static final class OptionsImpl implements AccessTransformersContainer.Options {
+        private final Project project;
+        private final ProviderFactory providers;
+
+        private @InputFiles FileCollection classpath;
+        private final @Optional @Input Property<String> mainClass;
+        private final @Input Property<String> javaLauncher;
+        private final @Input ListProperty<String> args;
+        private final @InputFile RegularFileProperty config;
+
+        @Inject
+        public OptionsImpl(Project project) {
+            this.project = project;
+            final ObjectFactory objects = project.getObjects();
+            this.providers = project.getProviders();
+
+            this.classpath = objects.fileCollection().from(DefaultTools.ACCESS_TRANSFORMERS);
+            this.mainClass = objects.property(String.class);
+            this.javaLauncher = objects.property(String.class).convention(this.defaultJavaLauncher());
+            this.args = objects.listProperty(String.class).convention(Constants.AT_DEFAULT_ARGS);
+            this.config = objects.fileProperty();
+        }
+
+        @Override
+        public void setClasspath(FileCollection files) {
+            this.classpath = files;
+        }
+
+        @Override
+        public void setClasspath(
+            @DelegatesTo(value = DependencyHandler.class, strategy = Closure.DELEGATE_FIRST)
+            @ClosureParams(value = SimpleType.class, options = "org.gradle.api.artifacts.dsl.DependencyHandler")
+            Closure<? extends Dependency> closure
+        ) {
+            this.classpath = this.project.getConfigurations().detachedConfiguration().withDependencies(
+                dependencies -> dependencies.addLater(this.providers.provider(
+                    () -> Closures.<Dependency>invoke(this.project.getDependencies(), closure).copy()
+                ))
+            );
+        }
+
+        @Override
+        public void setMainClass(Provider<String> mainClass) {
+            this.mainClass.set(mainClass);
+        }
+
+        @Override
+        public void setMainClass(String mainClass) {
+            this.mainClass.set(mainClass);
+        }
+
+        private Provider<String> defaultJavaLauncher() {
+            return this.providers.provider(() -> {
+                final JavaPluginExtension java = this.project.getExtensions().getByType(JavaPluginExtension.class);
+                final JavaToolchainService javaToolchains = this.project.getExtensions().getByType(JavaToolchainService.class);
+                final JavaLanguageVersion version = JavaLanguageVersion.of(Constants.AT_MIN_JAVA);
+
+                JavaToolchainSpec currentToolchain = java.getToolchain();
+                Provider<JavaLauncher> launcher = currentToolchain.getLanguageVersion().get().canCompileOrRun(version)
+                    ? javaToolchains.launcherFor(currentToolchain)
+                    : javaToolchains.launcherFor(spec -> spec.getLanguageVersion().set(version));
+
+                return launcher.map(l -> l.getExecutablePath().toString()).get();
+            });
+        }
+
+        @Override
+        public void setJavaLauncher(Provider<? extends JavaLauncher> javaLauncher) {
+            this.javaLauncher.set(javaLauncher.map(java -> java.getExecutablePath().toString()));
+        }
+
+        @Override
+        public void setJavaLauncher(JavaLauncher javaLauncher) {
+            this.javaLauncher.set(javaLauncher.getExecutablePath().toString());
+        }
+
+        @Override
+        public void setArgs(Iterable<String> args) {
+            this.args.set(args);
+        }
+
+        @Override
+        public void setArgs(Provider<? extends Iterable<String>> args) {
+            this.args.set(args);
+        }
+
+        @Override
+        public void setConfig(Provider<?> configFile) {
+            this.config.fileProvider(this.providers.provider(() -> {
+                Object value = configFile.getOrNull();
+                if (value == null)
+                    return null;
+                else if (value instanceof FileSystemLocation)
+                    value = ((FileSystemLocation) value).getAsFile();
+
+                // if Project#file becomes inaccessible, use ProjectLayout#files
+                return this.project.file(value, PathValidation.FILE);
+            }));
+        }
+
+        @Override
+        public void setConfig(RegularFile configFile) {
+            this.config.set(configFile);
+        }
+
+        @Override
+        public void setConfig(File configFile) {
+            this.config.set(configFile);
+        }
+
+        @Override
+        public void setConfig(Object configFile) {
+            this.config.fileProvider(this.providers.provider(
+                // if Project#file becomes inaccessible, use ProjectLayout#files
+                () -> this.project.file(configFile, PathValidation.FILE)
+            ));
+        }
+    }
+}

--- a/at-gradle/src/main/java/net/minecraftforge/accesstransformers/gradle/AccessTransformersExtension.java
+++ b/at-gradle/src/main/java/net/minecraftforge/accesstransformers/gradle/AccessTransformersExtension.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) Forge Development LLC
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+package net.minecraftforge.accesstransformers.gradle;
+
+import groovy.lang.Closure;
+import groovy.lang.DelegatesTo;
+import groovy.transform.stc.ClosureParams;
+import groovy.transform.stc.SimpleType;
+import org.gradle.api.Action;
+import org.gradle.api.attributes.Attribute;
+import org.jetbrains.annotations.ApiStatus;
+
+/// The extension interface for the AccessTransformers Gradle plugin.
+///
+/// Consumers must register at least one container using [#register(Attribute, Action)] (or using [#register(Action)] to
+/// use the default attribute). This extension acts as a delegate to the last registered container, but consumers can
+/// also use the return value of the registration to use multiple containers in a single project.
+///
+/// @apiNote This interface is effectively sealed and [must not be extended][ApiStatus.NonExtendable].
+@ApiStatus.NonExtendable // Sealed types were not added until Java 15
+public interface AccessTransformersExtension extends AccessTransformersContainer {
+    /// The name for this extension when added to [projects][org.gradle.api.Project].
+    String NAME = "accessTransformers";
+
+    /// The default attribute used by [#register(Action)].
+    ///
+    /// It is recommended that consumers use their own attributes if they plan on registering more than one container
+    /// per build.
+    Attribute<Boolean> DEFAULT_ATTRIBUTE = Attribute.of("net.minecraftforge.accesstransformers.transformed", Boolean.class);
+
+    /// Registers a new container, with the given options, using the [default attribute][#DEFAULT_ATTRIBUTE].
+    ///
+    /// @param options The options to apply
+    /// @return The registered container
+    /// @see AccessTransformersContainer.Options
+    default AccessTransformersContainer register(Action<? super AccessTransformersContainer.Options> options) {
+        return this.register(AccessTransformersExtension.DEFAULT_ATTRIBUTE, options);
+    }
+
+    /// Registers a new container, with the given options, using the [default attribute][#DEFAULT_ATTRIBUTE].
+    ///
+    /// @param options The options to apply
+    /// @return The registered container
+    /// @see AccessTransformersContainer.Options
+    @SuppressWarnings("rawtypes") // public-facing closure
+    default AccessTransformersContainer register(
+        @DelegatesTo(value = AccessTransformersContainer.Options.class, strategy = Closure.DELEGATE_FIRST)
+        @ClosureParams(value = SimpleType.class, options = "net.minecraftforge.accesstransformers.gradle.AccessTransformersContainer.Options")
+        Closure options
+    ) {
+        return this.register(DEFAULT_ATTRIBUTE, options);
+    }
+
+    /// Registers a new container using the given attribute and options.
+    ///
+    /// @param attribute The boolean attribute to use for this container
+    /// @param options   The options to apply
+    /// @return The registered container
+    /// @see AccessTransformersContainer.Options
+    default AccessTransformersContainer register(Attribute<Boolean> attribute, Action<? super AccessTransformersContainer.Options> options) {
+        return register(attribute, Closures.action(this, options));
+    }
+
+    /// Registers a new container using the given attribute and options.
+    ///
+    /// @param attribute The boolean attribute to use for this container
+    /// @param options   The options to apply
+    /// @return The registered container
+    /// @see AccessTransformersContainer.Options
+    @SuppressWarnings("rawtypes") // public-facing closure
+    AccessTransformersContainer register(
+        Attribute<Boolean> attribute,
+        @DelegatesTo(value = AccessTransformersContainer.Options.class, strategy = Closure.DELEGATE_FIRST)
+        @ClosureParams(value = SimpleType.class, options = "net.minecraftforge.accesstransformers.gradle.AccessTransformersContainer.Options")
+        Closure options
+    );
+}

--- a/at-gradle/src/main/java/net/minecraftforge/accesstransformers/gradle/AccessTransformersExtensionImpl.java
+++ b/at-gradle/src/main/java/net/minecraftforge/accesstransformers/gradle/AccessTransformersExtensionImpl.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) Forge Development LLC
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+package net.minecraftforge.accesstransformers.gradle;
+
+import groovy.lang.Closure;
+import groovy.lang.DelegatesTo;
+import groovy.transform.stc.ClosureParams;
+import groovy.transform.stc.SimpleType;
+import org.gradle.api.Project;
+import org.gradle.api.artifacts.Dependency;
+import org.gradle.api.attributes.Attribute;
+import org.jetbrains.annotations.Nullable;
+
+final class AccessTransformersExtensionImpl implements AccessTransformersExtension {
+    private final Project project;
+
+    private @Nullable AccessTransformersContainer container;
+
+    AccessTransformersExtensionImpl(Project project) {
+        this.project = project;
+    }
+
+    @Override
+    @SuppressWarnings("rawtypes") // public-facing closure
+    public AccessTransformersContainer register(
+        Attribute<Boolean> attribute,
+        @DelegatesTo(value = AccessTransformersContainer.Options.class, strategy = Closure.DELEGATE_FIRST)
+        @ClosureParams(value = SimpleType.class, options = "net.minecraftforge.accesstransformers.gradle.AccessTransformersContainer.Options")
+        Closure options
+    ) {
+        return this.container = AccessTransformersContainer.register(this.project, attribute, options);
+    }
+
+    private AccessTransformersContainer getContainer() {
+        if (this.container == null)
+            throw new IllegalStateException("Cannot configure options for AccessTransformers without having registered one! Use accessTransformers#register in your project.");
+
+        return this.container;
+    }
+
+    @Override
+    public Attribute<Boolean> getAttribute() {
+        return this.getContainer().getAttribute();
+    }
+
+    @Override
+    @SuppressWarnings("rawtypes") // public-facing closure
+    public void options(
+        @DelegatesTo(value = AccessTransformersContainer.Options.class, strategy = Closure.DELEGATE_FIRST)
+        @ClosureParams(value = SimpleType.class, options = "net.minecraftforge.accesstransformers.gradle.AccessTransformersContainer.Options")
+        Closure closure
+    ) {
+        this.getContainer().options(closure);
+    }
+
+    @Override
+    @SuppressWarnings("rawtypes") // public-facing closure
+    public Dependency dep(
+        Object dependencyNotation,
+        @DelegatesTo(Dependency.class)
+        @ClosureParams(value = SimpleType.class, options = "org.gradle.api.artifacts.Dependency")
+        Closure closure
+    ) {
+        return this.getContainer().dep(dependencyNotation, closure);
+    }
+}

--- a/at-gradle/src/main/java/net/minecraftforge/accesstransformers/gradle/AccessTransformersPlugin.java
+++ b/at-gradle/src/main/java/net/minecraftforge/accesstransformers/gradle/AccessTransformersPlugin.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) Forge Development LLC
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+package net.minecraftforge.accesstransformers.gradle;
+
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.ProviderFactory;
+
+import javax.inject.Inject;
+import java.io.File;
+import java.nio.file.Files;
+
+abstract class AccessTransformersPlugin implements Plugin<Project> {
+    static final Logger LOGGER = Logging.getLogger(AccessTransformersPlugin.class);
+
+    private final ObjectFactory objects;
+    private final ProviderFactory providers;
+
+    @Inject
+    public AccessTransformersPlugin(ObjectFactory objects, ProviderFactory providers) {
+        this.objects = objects;
+        this.providers = providers;
+    }
+
+    @Override
+    public void apply(Project project) {
+        final DirectoryProperty globalCaches = this.objects.directoryProperty().fileProvider(this.providers.provider(() -> {
+            File dir = new File(project.getGradle().getGradleUserHomeDir(), "caches/" + Constants.CACHES_PATH_GLOBAL);
+            Files.createDirectories(dir.toPath());
+            return dir;
+        }));
+
+        // init default tools
+        DefaultTools.start(globalCaches);
+
+        // init accessTransformers extension
+        project.getExtensions().add(
+            AccessTransformersExtension.class,
+            AccessTransformersExtension.NAME,
+            new AccessTransformersExtensionImpl(project)
+        );
+    }
+}

--- a/at-gradle/src/main/java/net/minecraftforge/accesstransformers/gradle/ArtifactAccessTransformer.java
+++ b/at-gradle/src/main/java/net/minecraftforge/accesstransformers/gradle/ArtifactAccessTransformer.java
@@ -1,0 +1,305 @@
+/*
+ * Copyright (c) Forge Development LLC
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+package net.minecraftforge.accesstransformers.gradle;
+
+import net.minecraftforge.util.hash.HashStore;
+import org.apache.groovy.util.Maps;
+import org.gradle.api.Action;
+import org.gradle.api.artifacts.transform.InputArtifact;
+import org.gradle.api.artifacts.transform.TransformAction;
+import org.gradle.api.artifacts.transform.TransformOutputs;
+import org.gradle.api.artifacts.transform.TransformParameters;
+import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.file.FileCollection;
+import org.gradle.api.file.FileSystemLocation;
+import org.gradle.api.file.RegularFile;
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
+import org.gradle.api.provider.ListProperty;
+import org.gradle.api.provider.Property;
+import org.gradle.api.provider.Provider;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.InputDirectory;
+import org.gradle.api.tasks.InputFile;
+import org.gradle.api.tasks.InputFiles;
+import org.gradle.api.tasks.Optional;
+import org.gradle.process.ExecOperations;
+import org.gradle.process.ExecResult;
+
+import javax.inject.Inject;
+import java.io.File;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+/// Transforms artifacts using AccessTransformers.
+///
+/// In ForgeGradle, this is only applied to the Minecraft classes artifact. It can, however, be apoplied to any artifact
+/// as long as it is a [jar][org.gradle.api.artifacts.type.ArtifactTypeDefinition#JAR_TYPE] file.
+public abstract class ArtifactAccessTransformer implements TransformAction<ArtifactAccessTransformer.Parameters> {
+    private static final Logger LOGGER = Logging.getLogger(ArtifactAccessTransformer.class);
+
+    // If your IDE is showing an error, ignore it. Pattern#LITERAL ignores RegEx entirely.
+    // We are using these to avoid compiling the pattern each time.
+    private static final Pattern ARG_INJAR = Pattern.compile("{inJar}", Pattern.LITERAL);
+    private static final Pattern ARG_ATFILE = Pattern.compile("{atFile}", Pattern.LITERAL);
+    private static final Pattern ARG_OUTJAR = Pattern.compile("{outJar}", Pattern.LITERAL);
+    private static final Pattern ARG_LOGFILE = Pattern.compile("{logFile}", Pattern.LITERAL);
+
+    /// The parameters for the transform action.
+    public interface Parameters extends TransformParameters {
+        /// The dependency configuration to resolve where AccessTransformers will be found in.
+        ///
+        /// @return A property for the AccessTransformers dependency
+        @InputFiles Property<FileCollection> getClasspath();
+
+        /// The main class for AccessTransformers.
+        ///
+        /// @return A property for the main class to use
+        /// @apiNote This is only required if you are providing a custom AccessTransformers which is not a single jar.
+        @Optional @Input Property<String> getMainClass();
+
+        /// The **executable path** of the Java launcher to use to run AccessTransformers.
+        ///
+        /// This can be acquired by mapping (a [provider][Provider] of) a [org.gradle.jvm.toolchain.JavaLauncher] to
+        /// [org.gradle.jvm.toolchain.JavaLauncher#getExecutablePath()] -> [org.gradle.api.file.RegularFile#getAsFile()]
+        /// -> [File#getAbsolutePath()].
+        ///
+        /// @return A property for the path of the Java launcher
+        @Input Property<String> getJavaLauncher();
+
+        /// The arguments to pass into AccessTransformers.
+        ///
+        /// These arguments accept tokens that will be replaced when the transform action is run.
+        ///
+        /// - `inJar` - The input jar
+        /// - `atFile` - The AccessTransformers configuration file
+        /// - `outJar` - The output jar
+        /// - `logFile` - The log file
+        ///
+        /// @return A property for the arguments
+        @Input ListProperty<String> getArgs();
+
+        /// The AccessTransformer configuration to use.
+        ///
+        /// This is usually named `accesstransformer.cfg`. In Forge, it is required in production that this file exists
+        /// in the mod jar's `META-INF` directory.
+        ///
+        /// @return A property for the AccessTransformer configuration
+        @InputFile RegularFileProperty getConfig();
+
+        /// The caches directory to use.
+        ///
+        /// This will include non-[transform output][TransformOutputs] files, such as in-house caching for the
+        /// transformation process.
+        ///
+        /// @return A property for the caches directory
+        @InputDirectory DirectoryProperty getCachesDir();
+    }
+
+    private final ExecOperations execOperations;
+
+    /// The default constructor that is invoked by Gradle to instantiate this transform action.
+    ///
+    /// @param execOperations The exec operations used by this transform action
+    @Inject
+    public ArtifactAccessTransformer(ExecOperations execOperations) {
+        this.execOperations = execOperations;
+    }
+
+    /// The artifact to transform with AccessTransformers.
+    ///
+    /// @return A property for the input artifact
+    protected abstract @InputArtifact Provider<FileSystemLocation> getInputArtifact();
+
+    /// Runs the transform action on the input artifact, queuing it for transformation with AccessTransformers.
+    ///
+    /// There are a few key distinctions that set this transform action apart from more traditional actions in Gradle
+    /// and other plugins:
+    ///
+    /// - If the [AccessTransformers configuration][Parameters#getConfig()] is unspecified or does not
+    /// exist, this transformation is skipped entirely.
+    ///   - Gradle detects changes to this file, so if it is changed, this transform action will be invoked by Gradle.
+    /// - This transformer uses in-house caching to detect if the input artifact actually needs to be transformed in the
+    /// first place.
+    ///   - If caches are hit and an existing output is found, the transformation process is skipped entirely.
+    ///   - Due to Gradle using transient caching for its artifact transforms, this is required to avoid unnecessarily
+    /// jar transformations, lengthening the build/sync time.
+    ///
+    /// @param outputs The outputs for this transform action
+    @Override
+    public void transform(TransformOutputs outputs) {
+        Parameters parameters = this.getParameters();
+
+        // inputs
+        File inJar = this.getInputArtifact().get().getAsFile();
+        File atFile = parameters.getConfig().map(RegularFile::getAsFile).getOrNull();
+        if (atFile == null) {
+            LOGGER.warn("WARNING: Access transformer configuration missing or not provided, skipping transformation for {}", inJar.getName());
+            outputs.file(inJar);
+            return;
+        }
+
+        // outputs
+        String outJarName = inJar.getName().replace(".jar", "-at.jar");
+        File outJar = this.file(outJarName);
+        File logFile = this.file(outJar.getName() + ".log");
+
+        // caches
+        DirectoryProperty cachesDir = parameters.getCachesDir();
+
+        // aforementioned in-house caching
+        HashStore cache = new HashStore(cachesDir.get().getAsFile())
+            .load(cachesDir.file(outJarName + ".cache").get().getAsFile())
+            .add("atFile", atFile)
+            .add("inJar", inJar)
+            .add("outJar", outJar);
+
+        if (outJar.exists() && cache.isSame()) {
+            LOGGER.info("Access transformer output up-to-date, skipping transformation for {}", inJar.getName());
+        } else {
+            LOGGER.info("Access transformer started. Input jar: {}", inJar.getAbsolutePath());
+            ExecResult result = this.execOperations.javaexec(exec -> {
+                OutputStream stream = toLog(LOGGER::info);
+                exec.setStandardOutput(stream);
+                exec.setErrorOutput(stream);
+
+                exec.setExecutable(parameters.getJavaLauncher().get());
+                exec.setClasspath(parameters.getClasspath().get());
+                setOptional(exec.getMainClass(), parameters.getMainClass());
+
+                Map<Pattern, String> substitutions = Maps.of(
+                    ARG_INJAR, inJar.getAbsolutePath(),
+                    ARG_ATFILE, atFile.getAbsolutePath(),
+                    ARG_OUTJAR, outJar.getAbsolutePath(),
+                    ARG_LOGFILE, logFile.getAbsolutePath()
+                );
+                exec.setArgs(parameters
+                    .getArgs().get()
+                    .stream()
+                    .map(arg -> replace(arg, substitutions))
+                    .collect(Collectors.toList())
+                );
+            });
+
+            try {
+                result.rethrowFailure();
+                result.assertNormalExitValue();
+            } catch (Exception e) {
+                /*
+                this.getReporter().throwing(e, id("access-transformer-failed", "Access transformer failed"), spec -> spec
+                    .details("""
+                        The access transformer failed to apply the transformations.
+                        This could potentially be caused by an invalid access transformer configuration.
+                        Input Jar: %s
+                        AccessTransformer Config: %s"""
+                        .formatted(inJar, atFile))
+                    .severity(Severity.ERROR)
+                    .stackLocation()
+                    .fileLocation(atFile.getAbsolutePath())
+                    .solution("Check your access transformer configuration file and ensure it is valid.")
+                    .solution(HELP_MESSAGE)
+                );
+                 */
+                LOGGER.error(
+                    "The access transformer failed to apply the transformations.\n" +
+                        "This could potentially be caused by an invalid access transformer configuration.\n" +
+                        "Input Jar: {}\n" +
+                        "AccessTransformer Config: {}\n" +
+                        '\n' +
+                        "Check your access transformer configuration file and ensure it is valid.",
+                    inJar, atFile);
+                throw new RuntimeException("Failed to apply access transformers to " + inJar.getName(), e);
+            }
+
+            LOGGER.info("Access transformer completed. Output jar: {}", outJar.getAbsolutePath());
+            cache.add("outJar", outJar).save();
+        }
+
+        // transform output
+        Path output = outputs.file(outJarName).toPath();
+
+        try {
+            Files.copy(
+                outJar.toPath(),
+                output,
+                StandardCopyOption.REPLACE_EXISTING
+            );
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to copy access transformer output to destination: " + output.toAbsolutePath(), e);
+        }
+    }
+
+    /// Conditionally set the given provider's value to the given property's value if the property is
+    /// [present][Provider#isPresent()].
+    ///
+    /// @param from The provider value to apply
+    /// @param to   The property to apply the new value to
+    /// @param <T>  The type of property
+    private static <T> void setOptional(Property<T> to, Provider<? extends T> from) {
+        if (from.isPresent()) to.set(from);
+    }
+
+    /// Uses [String#replace(CharSequence, CharSequence)] but with pre-compiled patterns provided in the given map.
+    ///
+    /// @param s             The string to replace
+    /// @param substitutions The map of substitutions to use
+    /// @see String#replace(CharSequence, CharSequence)
+    private static String replace(String s, Map<Pattern, String> substitutions) {
+        for (Map.Entry<Pattern, String> entry : substitutions.entrySet()) {
+            s = entry.getKey().matcher(s).replaceAll(Matcher.quoteReplacement(entry.getValue()));
+        }
+
+        return s;
+    }
+
+    /// Creates a file in the caches directory.
+    ///
+    /// This uses a [RegularFileProperty] to ensure that Gradle is aware of this file's usage by this transform action.
+    ///
+    /// @param path The path, from the caches directory, to the file
+    /// @return The file
+    private File file(String path) {
+        return this.getParameters().getCachesDir().file(path).map(file -> {
+            Path p = file.getAsFile().toPath();
+            try {
+                Files.createDirectories(p.getParent());
+            } catch (IOException e) {
+                throw new RuntimeException("Failed to create parent directrory for " + p.toAbsolutePath(), e);
+            }
+
+            return file;
+        }).get().getAsFile();
+    }
+
+    /// Creates an output stream that logs to the given action.
+    ///
+    /// @param logger The logger to log to
+    /// @return The output stream
+    private static OutputStream toLog(Action<? super String> logger) {
+        return new OutputStream() {
+            private StringBuffer buffer = new StringBuffer(512);
+
+            @Override
+            public void write(int b) {
+                if (b == '\r' || b == '\n') {
+                    if (this.buffer.length() != 0) {
+                        logger.execute(this.buffer.toString());
+                        this.buffer = new StringBuffer(512);
+                    }
+                } else {
+                    this.buffer.append(b);
+                }
+            }
+        };
+    }
+}

--- a/at-gradle/src/main/java/net/minecraftforge/accesstransformers/gradle/Closures.java
+++ b/at-gradle/src/main/java/net/minecraftforge/accesstransformers/gradle/Closures.java
@@ -1,0 +1,125 @@
+package net.minecraftforge.accesstransformers.gradle;
+
+import groovy.lang.Closure;
+import groovy.lang.DelegatesTo;
+import groovy.transform.stc.FirstParam;
+import org.codehaus.groovy.runtime.InvokerInvocationException;
+import org.gradle.api.Action;
+import org.jetbrains.annotations.UnknownNullability;
+
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+// copied from FG7
+final class Closures {
+    /// Invokes a given closure with the given object as the delegate type and parameter.
+    ///
+    /// This is used to work around a Groovy DSL implementation detail that involves dynamic objects within
+    /// buildscripts. By default, Gradle will attempt to locate the dynamic object that is being referenced within a
+    /// closure and use handlers within the buildscript's class loader to work with it. This is unfortunately very
+    /// unfriendly to trying to use closures on traditional objects. The solution is to both manually set the closure's
+    /// [delegate][Closure#setDelegate(Object)], [resolve strategy][Closure#setResolveStrategy(int)], and temporarily
+    /// swap out the [current thread's context class loader][Thread#setContextClassLoader(ClassLoader)] with that of the
+    /// closure in order to force resolution of the groovy metaclass to the delegate object.
+    ///
+    /// I'm sorry.
+    ///
+    /// @see org.gradle.api.internal.AbstractTask.ClosureTaskAction#doExecute(org.gradle.api.Task)
+    @SuppressWarnings({"rawtypes", "unchecked", "JavadocReference"})
+    static <T> @UnknownNullability T invoke(Object object, @DelegatesTo(value = FirstParam.class, strategy = Closure.DELEGATE_FIRST) Closure closure) {
+        closure.setDelegate(object);
+        closure.setResolveStrategy(Closure.DELEGATE_FIRST);
+        ClassLoader original = Thread.currentThread().getContextClassLoader();
+        Thread.currentThread().setContextClassLoader(closure.getClass().getClassLoader());
+        try {
+            Object ret = closure.getMaximumNumberOfParameters() == 0 ? closure.call() : closure.call(object);
+            return ret != null ? (T) ret : null;
+        } catch (InvokerInvocationException e) {
+            Throwable cause = e.getCause();
+            throw cause instanceof RuntimeException ? (RuntimeException) cause : e;
+        } finally {
+            Thread.currentThread().setContextClassLoader(original);
+        }
+    }
+
+    /// Creates a closure backed by the given function
+    ///
+    /// @param owner    The owner of the closure
+    /// @param function The function to apply
+    /// @param <T>      The parameter type of the function
+    /// @param <R>      The return type of the function
+    static <T, R> Closure<R> function(Object owner, Function<? super T, ? extends R> function) {
+        return new Functional<T, R>(owner, function);
+    }
+
+    /// Creates a closure backed by the given action.
+    ///
+    /// @apiNote For instance methods only.
+    /// @param owner  The owner of the closure
+    /// @param action The action to execute
+    /// @param <T>    The type of the action
+    /// @return The closure
+    static <T> Closure<Void> action(Object owner, Action<? super T> action) {
+        return consumer(owner, action::execute);
+    }
+
+    /// Creates a closure backed by the given consumer.
+    ///
+    /// @apiNote For instance methods only.
+    /// @param owner    The owner of the closure
+    /// @param consumer The consumer to execute
+    /// @param <T>      The type of the action
+    /// @return The closure
+    static <T> Closure<Void> consumer(Object owner, Consumer<? super T> consumer) {
+        return new Consuming<>(owner, consumer);
+    }
+
+    /// Creates an empty closure.
+    ///
+    /// @apiNote For instance methods only.
+    /// @param owner The owner of the closure
+    /// @return The empty closure
+    static Closure<Void> empty(Object owner) {
+        return new Empty(owner);
+    }
+
+    private static final class Functional<T, R> extends Closure<R> {
+        private final Function<? super T, ? extends R> function;
+
+        private Functional(Object owner, Function<? super T, ? extends R> function) {
+            super(owner, owner);
+            this.function = function;
+        }
+
+        @SuppressWarnings("unused") // invoked by Groovy
+        public R doCall(T object) {
+            return this.function.apply(object);
+        }
+    }
+
+    private static final class Consuming<T> extends Closure<Void> {
+        private final Consumer<? super T> consumer;
+
+        private Consuming(Object owner, Consumer<? super T> consumer) {
+            super(owner, owner);
+            this.consumer = consumer;
+        }
+
+        @SuppressWarnings("unused") // invoked by Groovy
+        public Void doCall(T object) {
+            this.consumer.accept(object);
+            return null;
+        }
+    }
+
+    private static class Empty extends Closure<Void> {
+        public Empty(Object owner) {
+            super(owner, owner);
+        }
+
+        @SuppressWarnings("unused") // invoked by Groovy
+        public Void doCall() {
+            return null;
+        }
+    }
+}

--- a/at-gradle/src/main/java/net/minecraftforge/accesstransformers/gradle/Constants.java
+++ b/at-gradle/src/main/java/net/minecraftforge/accesstransformers/gradle/Constants.java
@@ -1,0 +1,20 @@
+package net.minecraftforge.accesstransformers.gradle;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+public interface Constants {
+    String CACHES_PATH_GLOBAL = /* gradleUserHomeDir + */ "minecraftforge/accesstransformers";
+    String CACHES_PATH_LOCAL = /* projectLayout.buildDirectory + */ "accesstransformers";
+
+    String AT_VERSION = "8.2.2";
+    String AT_DOWNLOAD_URL = "https://maven.minecraftforge.net/net/minecraftforge/accesstransformers/" + AT_VERSION + "/accesstransformers-" + AT_VERSION + "-fatjar.jar";
+    int AT_MIN_JAVA = 8;
+    List<String> AT_DEFAULT_ARGS = Collections.unmodifiableList(Arrays.asList(
+        "--inJar", "{inJar}",
+        "--atFile", "{atFile}",
+        "--outJar", "{outJar}",
+        "--logFile", "{logFile}"
+    ));
+}

--- a/at-gradle/src/main/java/net/minecraftforge/accesstransformers/gradle/DefaultTools.java
+++ b/at-gradle/src/main/java/net/minecraftforge/accesstransformers/gradle/DefaultTools.java
@@ -1,0 +1,74 @@
+package net.minecraftforge.accesstransformers.gradle;
+
+import net.minecraftforge.util.download.DownloadUtils;
+import net.minecraftforge.util.hash.HashStore;
+import org.gradle.api.file.DirectoryProperty;
+import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.UnknownNullability;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Objects;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
+
+import static net.minecraftforge.accesstransformers.gradle.AccessTransformersPlugin.LOGGER;
+
+enum DefaultTools implements Callable<File> {
+    ACCESS_TRANSFORMERS("accesstransformers.jar", Constants.AT_DOWNLOAD_URL);
+
+    private final String fileName;
+    private final String downloadUrl;
+
+    private static @UnknownNullability DirectoryProperty caches;
+    private @Nullable Future<File> future;
+
+    DefaultTools(String fileName, String downloadUrl) {
+        this.fileName = fileName;
+        this.downloadUrl = downloadUrl;
+    }
+
+    static void start(DirectoryProperty cachesDir) {
+        if (caches != null) return;
+        caches = cachesDir;
+
+        for (DefaultTools tool : values())
+            tool.future = CompletableFuture.supplyAsync(tool::download);
+    }
+
+    private File download() {
+        // outputs
+        File outFile = caches.file(this.fileName).get().getAsFile();
+        String name = outFile.getName();
+
+        // in-house caching
+        HashStore cache = HashStore.fromFile(outFile)
+            .add("tool", outFile)
+            .add("url", this.downloadUrl);
+
+        if (outFile.exists() && cache.isSame()) {
+            LOGGER.info("Default tool already downloaded: {}", name);
+        } else {
+            LOGGER.info("Downloading default tool: {}", name);
+            try {
+                DownloadUtils.downloadFile(outFile, this.downloadUrl);
+            } catch (IOException e) {
+                throw new RuntimeException("Failed to download default tool: " + name, e);
+            }
+
+            cache.add("tool", outFile).save();
+        }
+
+        return outFile;
+    }
+
+    @Override
+    public File call() throws Exception {
+        try {
+            return Objects.requireNonNull(this.future, "Default tools are not initialized").get();
+        } catch (Throwable e) {
+            throw new IOException("Failed to download default tool: " + fileName, e);
+        }
+    }
+}

--- a/at-gradle/src/main/java/net/minecraftforge/accesstransformers/gradle/package-info.java
+++ b/at-gradle/src/main/java/net/minecraftforge/accesstransformers/gradle/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) Forge Development LLC
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+/// The AccessTransformers Gradle plugin enables Gradle projects to use AccessTransformers on dependencies with minimal
+/// hassle.
+@NotNullByDefault
+package net.minecraftforge.accesstransformers.gradle;
+
+import org.jetbrains.annotations.NotNullByDefault;

--- a/at-jmh/build.gradle
+++ b/at-jmh/build.gradle
@@ -1,14 +1,14 @@
 plugins {
     id 'java-library'
-    id 'net.minecraftforge.licenser'
+    alias libs.plugins.licenser
 }
 
 configurations {
-    jmhOnly
-}
+    dependencyScope('jmuRuntimeOnly')
 
-repositories {
-    mavenCentral()
+    resolvable('jmhRuntimeClasspath') {
+        extendsFrom jmuRuntimeOnly
+    }
 }
 
 java {
@@ -17,33 +17,31 @@ java {
 }
 
 license {
-    header = rootProject.file("LICENSE-header.txt")
+    header = rootProject.file('LICENSE-header.txt')
     newLine = false
 }
 
 dependencies {
     implementation rootProject
-    implementation libs.jmh.core
+    implementation testLibs.jmh.core
     implementation libs.asm
 
-    jmhOnly sourceSets.main.output
-    jmhOnly libs.bundles.jmh
+    jmuRuntimeOnly sourceSets.main.output
+    jmuRuntimeOnly testLibs.bundles.jmh
 
-    annotationProcessor libs.jmh.generator.annprocess
+    annotationProcessor testLibs.jmh.generator.annprocess
 }
 
 tasks.register('jmh', JavaExec) {
-    dependsOn rootProject.tasks.named('build')
+    dependsOn rootProject.tasks.named('check')
     dependsOn sourceSets.main.output
 
-    javaLauncher.set(javaToolchains.launcherFor {
-        languageVersion = JavaLanguageVersion.of(17)
-    })
+    javaLauncher = javaToolchains.launcherFor { languageVersion = JavaLanguageVersion.of(17) }
     jvmArgs = [
-            '-p', sourceSets.main.runtimeClasspath.asPath,
-            '--add-modules', 'ALL-MODULE-PATH',
+        '-p', sourceSets.main.runtimeClasspath.asPath,
+        '--add-modules', 'ALL-MODULE-PATH',
     ]
-    classpath = files(configurations.jmhOnly.asPath)
+    classpath = configurations.jmhRuntimeClasspath
     mainClass = 'org.openjdk.jmh.Main'
 
     args '-bm', 'avgt'  // benchmark mode

--- a/at-mlservice/build.gradle
+++ b/at-mlservice/build.gradle
@@ -1,14 +1,9 @@
 plugins {
-    id 'eclipse'
     id 'java-library'
-    id 'net.minecraftforge.licenser' version '1.0.1'
-    id 'net.minecraftforge.gradleutils' version '[2.3,2.4)'
-}
-
-repositories {
-    mavenCentral()
-    maven gradleutils.forgeMaven
-    mavenLocal()
+    id 'eclipse'
+    id 'idea'
+    alias libs.plugins.licenser
+    alias libs.plugins.gradleutils
 }
 
 java {
@@ -17,21 +12,21 @@ java {
 }
 
 license {
-    header = rootProject.file("LICENSE-header.txt")
+    header = rootProject.file('LICENSE-header.txt')
     newLine = false
 }
 
-test {
+tasks.named('test', Test) {
     useJUnitPlatform()
-    reports.html.destination = rootProject.file("build/reports/")
-    reports.junitXml.destination = rootProject.file("build/test-results/")
+    reports.html.outputLocation = rootProject.layout.buildDirectory.dir('reports')
+    reports.junitXml.outputLocation = rootProject.layout.buildDirectory.dir('test-results')
 }
 
 dependencies {
-    implementation(libs.modlauncher)
-    implementation(rootProject)
-    testImplementation(libs.junit.api)
-    testRuntimeOnly(libs.bundles.junit.runtime)
+    implementation libs.modlauncher
+    implementation rootProject
+    testImplementation testLibs.junit.api
+    testRuntimeOnly testLibs.bundles.junit.runtime
 }
 
 // Hack eclipse into knowing that the gradle deps are modules

--- a/at-test-jar/build.gradle
+++ b/at-test-jar/build.gradle
@@ -1,14 +1,9 @@
 plugins {
-    id 'eclipse'
     id 'java-library'
-    id 'net.minecraftforge.licenser' version '1.0.1'
-    id 'net.minecraftforge.gradleutils' version '[2.3,2.4)'
-}
-
-repositories {
-    mavenCentral()
-    maven gradleutils.forgeMaven
-    mavenLocal()
+    id 'eclipse'
+    id 'idea'
+    alias libs.plugins.licenser
+    alias libs.plugins.gradleutils
 }
 
 java {
@@ -16,7 +11,7 @@ java {
 }
 
 license {
-    header = rootProject.file("LICENSE-header.txt")
+    header = rootProject.file('LICENSE-header.txt')
 }
 
 // Hack eclipse into knowing that the gradle deps are modules

--- a/at-test/build.gradle
+++ b/at-test/build.gradle
@@ -1,14 +1,9 @@
 plugins {
-    id 'eclipse'
     id 'java-library'
-    id 'net.minecraftforge.licenser'
-    id 'net.minecraftforge.gradleutils'
-}
-
-repositories {
-    mavenCentral()
-    maven gradleutils.forgeMaven
-    mavenLocal()
+    id 'eclipse'
+    id 'idea'
+    alias libs.plugins.licenser
+    alias libs.plugins.gradleutils
 }
 
 java {
@@ -16,55 +11,63 @@ java {
 }
 
 license {
-    header = rootProject.file("LICENSE-header.txt")
+    header = rootProject.file('LICENSE-header.txt')
     newLine = false
 }
 
-test {
+tasks.named('test', Test) {
     useJUnitPlatform()
-    reports.html.destination = rootProject.file("build/reports/")
-    reports.junitXml.destination = rootProject.file("build/test-results/")
+    reports.html.outputLocation = rootProject.layout.buildDirectory.dir('reports')
+    reports.junitXml.outputLocation = rootProject.layout.buildDirectory.dir('test-results')
 }
 
 dependencies {
-    testImplementation(rootProject)
-    testImplementation(project(':at-mlservice'))
-    testImplementation(project(':at-test-jar'))
-    testImplementation(libs.junit.api)
-    testImplementation(libs.unsafe)
-    testImplementation(libs.securemodules)
-    testImplementation(libs.modlauncher)
-    testImplementation(libs.asm)
-    testImplementation(libs.asm.tree)
-    testImplementation(libs.jopt.simple)
-    testImplementation(libs.log4j.api)
-    testImplementation(libs.log4j.core)
-    testImplementation(libs.gson)
-    testRuntimeOnly(libs.bundles.junit.runtime)
-    testCompileOnly(libs.nulls)
+    testImplementation rootProject
+    testImplementation project(':at-mlservice')
+    testImplementation project(':at-test-jar')
+    testImplementation testLibs.junit.api
+    testImplementation testLibs.unsafe
+    testImplementation libs.securemodules
+    testImplementation libs.modlauncher
+    testImplementation libs.asm
+    testImplementation libs.asm.tree
+    testImplementation libs.jopt
+    testImplementation libs.log4j.api
+    testImplementation libs.log4j.core
+    testImplementation testLibs.gson
+    testRuntimeOnly testLibs.bundles.junit.runtime
+    testCompileOnly libs.nulls
 }
 
-tasks.register('testAll', AggregateTest) {
+final testAll = tasks.register('testAll', AggregateTest) {
     input = file('build/test-results/')
     output = rootProject.file('test_results.html')
 }
 
-VALID_VMS.each { javaVendor, javaVersions ->
+def testFor(String javaVendor, int javaVersion, File output) {
+    tasks.<Test>register("test${javaVendor}${javaVersion}", Test) {
+        useJUnitPlatform()
+        classpath = sourceSets.test.runtimeClasspath
+        testClassesDirs = sourceSets.test.output.classesDirs
+        javaLauncher = javaToolchains.launcherFor {
+            vendor = JvmVendorSpec.of(javaVendor.toUpperCase(Locale.ROOT))
+            languageVersion = JavaLanguageVersion.of(javaVersion)
+            implementation = JvmImplementation.VENDOR_SPECIFIC
+        }
+        reports.html.outputLocation = layout.buildDirectory.dir("test-reports/${javaVendor}-${javaVersion}")
+        reports.junitXml.outputLocation = output
+    }
+}
+
+(VALID_VMS as Map<String, List<Integer>>).each { javaVendor, javaVersions ->
     javaVersions.each { javaVersion ->
         def output = file("build/test-results/${javaVendor}-${javaVersion}/")
         output.mkdirs()
-        def task = tasks.register("test${javaVendor}${javaVersion}", Test) {
-            useJUnitPlatform()
-            javaLauncher.set(javaToolchains.launcherFor {
-                it.vendor.set(JvmVendorSpec."${javaVendor.toUpperCase(Locale.ROOT)}" as JvmVendorSpec)
-                it.languageVersion.set(JavaLanguageVersion.of(javaVersion))
-                it.implementation.set(JvmImplementation.VENDOR_SPECIFIC)
-            })
-            reports.html.destination = file("build/test-reports/${javaVendor}-${javaVersion}/")
-            reports.junitXml.destination = output
+        def task = testFor(javaVendor, javaVersion, output)
+        testAll.configure {
+            inputs.dir(output)
+            dependsOn(task)
+            mustRunAfter(task)
         }
-        testAll.inputs.dir(output)
-        testAll.dependsOn(task)
-        testAll.mustRunAfter(task)
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,62 +1,52 @@
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
-import net.minecraftforge.gradleutils.PomUtils
 
 plugins {
     id 'java-library'
     id 'maven-publish'
     id 'eclipse'
-    id 'com.github.ben-manes.versions' version '0.51.0'
-    id 'com.github.johnrengelman.shadow' version '8.1.1'
-    id 'net.minecraftforge.licenser' version '1.0.1'
-    id 'net.minecraftforge.gradleutils' version '[2.3,2.4)'
+    id 'idea'
+    alias libs.plugins.versions
+    alias libs.plugins.shadow
+    alias libs.plugins.licenser
+    alias libs.plugins.gradleutils
 }
 
-group 'net.minecraftforge'
+final projectDisplayName = 'AccessTransformers'
+final projectVendor = 'Forge Development LLC'
+description = 'Transforms class member access based on specification files.'
+group = 'net.minecraftforge'
+version = gitversion.tagOffset
 
-version = gradleutils.tagOffsetVersion
-println('Version: ' + version)
-
-repositories {
-    mavenCentral()
-    maven gradleutils.forgeMaven
-}
-
-license {
-    header = file('LICENSE-header.txt')
-    newLine = false
-}
+println "Version: $version"
 
 java {
     toolchain.languageVersion = JavaLanguageVersion.of(8)
     withSourcesJar()
 }
 
-tasks.named('jar', Jar).configure {
-    dependsOn ':at-mlservice:processResources'
-    dependsOn ':at-mlservice:compileJava'
-    doFirst {
-        from project(':at-mlservice').sourceSets.main.output
+tasks.named('jar', Jar) {
+    final map = [
+        'Specification-Title'   : projectDisplayName,
+        'Specification-Vendor'  : projectVendor,
+        'Specification-Version' : '1',
+        'Implementation-Title'  : projectDisplayName,
+        'Implementation-Version': project.version,
+        'Implementation-Vendor' : projectVendor
+    ]
+
+    manifest {
+        attributes(map, 'net/minecraftforge/accesstransformer/')
+        attributes(map, 'net/minecraftforge/accesstransformer/service/')
     }
 
-    ext.SPEC = '1' // Should be tag but whatever
-    manifest {
-        attributes([
-            'Specification-Title': 'accesstransformers',
-            'Specification-Vendor': 'Forge Development LLC',
-            'Specification-Version': SPEC,
-            'Implementation-Title': project.name,
-            'Implementation-Version': project.version,
-            'Implementation-Vendor': 'Forge Development LLC'
-        ] as java.util.LinkedHashMap, 'net/minecraftforge/accesstransformer/')
-        attributes([
-            'Specification-Title': 'accesstransformers',
-            'Specification-Vendor': 'Forge Development LLC',
-            'Specification-Version': SPEC,
-            'Implementation-Title': project.name,
-            'Implementation-Version': project.version,
-            'Implementation-Vendor': 'Forge Development LLC'
-        ] as java.util.LinkedHashMap, 'net/minecraftforge/accesstransformer/service/')
-    }
+    dependsOn ':at-mlservice:processResources'
+    dependsOn ':at-mlservice:compileJava'
+    from provider { project(':at-mlservice').sourceSets.main.output }
+}
+
+license {
+    header = rootProject.file('LICENSE-header.txt')
+    newLine = false
 }
 
 changelog {
@@ -64,22 +54,22 @@ changelog {
 }
 
 dependencies {
-    implementation(libs.jopt.simple)
-    implementation(libs.bundles.asm)
-    implementation(libs.log4j.api)
-    implementation(libs.log4j.core)
+    implementation libs.jopt
+    implementation libs.bundles.asm
+    implementation libs.log4j.api
+    implementation libs.log4j.core
 }
 
-tasks.named('shadowJar', ShadowJar).configure {
-    archiveClassifier = 'fatjar'
-    exclude '**/Log4j2Plugins.dat'
+tasks.named('shadowJar', ShadowJar) {
     manifest {
-        inheritFrom jar.manifest
         attributes([
-            'Main-Class': 'net.minecraftforge.accesstransformer.TransformerProcessor',
+            'Main-Class'   : 'net.minecraftforge.accesstransformer.TransformerProcessor',
             'Multi-Release': 'true'
         ])
     }
+
+    archiveClassifier = 'fatjar'
+    exclude '**/Log4j2Plugins.dat'
 }
 
 artifacts {
@@ -89,38 +79,28 @@ artifacts {
 publishing {
     publications.register('mavenJava', MavenPublication) {
         from components.java
-        artifactId = 'accesstransformers'
-        pom {
-            name = 'Access Transformers'
-            description = 'Transforms class member access based on specification files'
-            url = 'https://github.com/MinecraftForge/AccessTransformers'
-            PomUtils.setGitHubDetails(pom, 'AccessTransformers')
 
-            license PomUtils.Licenses.MIT
+        artifactId = 'accesstransformers'
+
+        pom { pom ->
+            name = projectDisplayName
+            description = project.description
+
+            gradleutils.pom.setGitHubDetails pom
+
+            licenses {
+                license gradleutils.pom.licenses.MIT
+            }
 
             developers {
-                developer PomUtils.Developers.LexManos
-                developer PomUtils.Developers.cpw
-                developer PomUtils.Developers.DemonWav
+                developer gradleutils.pom.developers.LexManos
+                developer gradleutils.pom.developers.cpw
+                developer gradleutils.pom.developers.DemonWav
             }
         }
     }
+
     repositories {
         maven gradleutils.publishingForgeMaven
     }
-}
-
-allprojects {
-    ext.VALID_VMS = [
-        'Adoptium':  [16, 17, 18, 19, 20, 21],
-        'Amazon':    [16, 17, 18, 19, 20, 21],
-        'Azul':      (16..21),
-        'BellSoft':  (16..21),
-        'Graal_VM':  [16, 17,     19, 20, 21],
-        'IBM':       [16, 17, 18, 19, 20    ],
-        'Microsoft': [16, 17,             21],
-        'Oracle':    (16..21),
-        'SAP':       (16..20)
-    ]
-    ext.VALID_VMS = [ 'Adoptium':  [16] ]
 }

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -2,13 +2,5 @@ plugins {
     id 'groovy'
 }
 
-repositories {
-    mavenCentral()
-    maven { url 'https://jitpack.io' }
-}
-
-java.toolchain.languageVersion = JavaLanguageVersion.of(17)
-
-dependencies {
-    implementation 'com.github.Steppschuh:Java-Markdown-Generator:1.3.2'
-}
+// sourceCompatibility instead of toolchain version so Gradle doesn't need to download a toolchain to compile us
+java.sourceCompatibility = JavaVersion.VERSION_1_8

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,7 @@
+org.gradle.caching=true
+org.gradle.parallel=true
+org.gradle.configureondemand=true
+
+# TODO [AccessTransformers][Gradle9] Enable
+#org.gradle.configuration-cache=true
+#org.gradle.configuration-cache.parallel=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,51 +1,85 @@
-pluginManagement {
-    repositories {
-        gradlePluginPortal()
-        maven { url = 'https://maven.minecraftforge.net/' }
-    }
-}
+import groovy.transform.Field
 
 plugins {
-    id 'org.gradle.toolchains.foojay-resolver-convention' version '0.7.0'
-}
-
-dependencyResolutionManagement {
-    versionCatalogs {
-        libs {
-            version('asm', '9.7')
-            library('asm',         'org.ow2.asm', 'asm'        ).versionRef('asm')
-            library('asm-tree',    'org.ow2.asm', 'asm-tree'   ).versionRef('asm')
-            library('asm-commons', 'org.ow2.asm', 'asm-commons').versionRef('asm')
-            bundle('asm', ['asm', 'asm-tree', 'asm-commons'])
-            
-			version('junit', '5.10.2')
-			library('junit-api', 'org.junit.jupiter', 'junit-jupiter-api').versionRef('junit')
-			library('junit-engine', 'org.junit.jupiter', 'junit-jupiter-engine').versionRef('junit')
-			library('junit-platform-launcher', 'org.junit.platform:junit-platform-launcher:1.10.2')
-			bundle('junit-runtime', ['junit-engine', 'junit-platform-launcher'])
-
-            library('unsafe', 'net.minecraftforge:unsafe:0.9.2')
-            library('modlauncher', 'net.minecraftforge:modlauncher:10.1.1') // Needs securemodules
-            library('securemodules', 'net.minecraftforge:securemodules:2.2.2') // Needs unsafe
-            library('gson', 'com.google.code.gson:gson:2.10.1')
-            library('jopt-simple', 'net.sf.jopt-simple:jopt-simple:5.0.4')
-            library('nulls', 'org.jetbrains:annotations:24.1.0')
-            
-            version('log4j', '2.19.0')
-            library('log4j-api',  'org.apache.logging.log4j', 'log4j-api' ).versionRef('log4j')
-            library('log4j-core', 'org.apache.logging.log4j', 'log4j-core').versionRef('log4j')
-
-            version('jmh', '1.37')
-            library('jmh-core', 'org.openjdk.jmh', 'jmh-core').versionRef('jmh')
-            library('jmh-generator-annprocess', 'org.openjdk.jmh', 'jmh-generator-annprocess').versionRef('jmh')
-            bundle('jmh', ['jmh-core', 'jmh-generator-annprocess'])
-        }
-    }
+    id 'org.gradle.toolchains.foojay-resolver-convention' version '0.10.0'
 }
 
 rootProject.name = 'AccessTransformers'
+
+includeBuild 'at-gradle'
+//includeBuild 'at-gradle-demo'
 include 'at-mlservice'
 include 'at-test'
 include 'at-test-jar'
 include 'at-jmh'
 
+private final @Field @Lazy Map<String, List<Integer>> jmhVms = {
+    final bulkTests = providers.gradleProperty('bulk_tests').<boolean>map { 'true'.equalsIgnoreCase(it) }.getOrElse(false)
+    return (!bulkTests ? [ 'Adoptium':  [16] ] : [
+        'Adoptium':  [16, 17, 18, 19, 20, 21],
+        'Amazon':    [16, 17, 18, 19, 20, 21],
+        'Azul':      (16..21),
+        'BellSoft':  (16..21),
+        'Graal_VM':  [16, 17,     19, 20, 21],
+        'IBM':       [16, 17, 18, 19, 20    ],
+        'Microsoft': [16, 17,             21],
+        'Oracle':    (16..21),
+        'SAP':       (16..20)
+    ]) as Map<String, List<Integer>>
+}()
+
+gradle.beforeProject { Project project ->
+    project.extensions.extraProperties.set('VALID_VMS', jmhVms)
+}
+
+dependencyResolutionManagement {
+    repositories {
+        maven { url = 'https://maven.minecraftforge.net' }
+        mavenCentral()
+    }
+
+    //@formatter:off
+    versionCatalogs {
+        register('libs') {
+            plugin 'versions',    'com.github.ben-manes.versions'  version '0.51.0'
+            plugin 'shadow',      'com.gradleup.shadow'            version '9.0.0-beta13'
+            plugin 'licenser',    'net.minecraftforge.licenser'    version '1.2.0'
+            plugin 'gradleutils', 'net.minecraftforge.gradleutils' version '2.6.1'
+
+            version 'asm', '9.7'
+            library 'asm',         'org.ow2.asm', 'asm'         versionRef 'asm'
+            library 'asm-tree',    'org.ow2.asm', 'asm-tree'    versionRef 'asm'
+            library 'asm-commons', 'org.ow2.asm', 'asm-commons' versionRef 'asm'
+            bundle 'asm', ['asm', 'asm-tree', 'asm-commons']
+
+            library 'jopt',          'net.sf.jopt-simple',   'jopt-simple'   version '5.0.4'
+            library 'nulls',         'org.jetbrains',        'annotations'   version '26.0.2'
+
+            version 'log4j', '2.19.0'
+            library 'log4j-api',  'org.apache.logging.log4j', 'log4j-api'  versionRef 'log4j'
+            library 'log4j-core', 'org.apache.logging.log4j', 'log4j-core' versionRef 'log4j'
+
+            library 'modlauncher',   'net.minecraftforge', 'modlauncher'   version '10.1.1' // Needs securemodules
+            library 'securemodules', 'net.minecraftforge', 'securemodules' version '2.2.2' // Needs unsafe
+        }
+
+        register('testLibs') {
+            description = 'Dependencies used exclusively for testing or test projects.'
+
+            library 'unsafe', 'net.minecraftforge',   'unsafe' version '0.9.2'
+            library 'gson',   'com.google.code.gson', 'gson'   version '2.10.1'
+
+            version 'junit', '5.10.2'
+            library 'junit-api',               'org.junit.jupiter',  'junit-jupiter-api'       versionRef 'junit'
+            library 'junit-engine',            'org.junit.jupiter',  'junit-jupiter-engine'    versionRef 'junit'
+            library 'junit-platform-launcher', 'org.junit.platform', 'junit-platform-launcher' version    '1.10.2'
+            bundle 'junit-runtime', ['junit-engine', 'junit-platform-launcher']
+
+            version 'jmh', '1.37'
+            library 'jmh-core',                 'org.openjdk.jmh', 'jmh-core'                 versionRef 'jmh'
+            library 'jmh-generator-annprocess', 'org.openjdk.jmh', 'jmh-generator-annprocess' versionRef 'jmh'
+            bundle 'jmh', ['jmh-core', 'jmh-generator-annprocess']
+        }
+    }
+    //@formatter:on
+}


### PR DESCRIPTION
This PR adds the AccessTransformers Gradle Plugin, which is a minimal, general-purpose plugin to allow using AccessTransformers in Gradle projects without needing to use ForgeGradle or building a separate solution.

The structure of this plugin is similar to FG7, with public types for consumers and private types as the implementation. Consumers can register a "container" with `accessTransformers.register()`. The `accessTransformers` extension acts as a reference to the last registered container, although it can also be stored using the return value of the register method. This plugin uses artifact transforms which themselves are registered using attributes. The default register method uses a default attribute, but it can only be used one time per project, after which any additional containers need to be registered with a unique attribute of type `Attribute<Boolean>`.

To allow for compatibility with older projects, the minimum Gradle version is `7.3` (which added `ArtifactTypeDefinition.JAR_TYPE`) and the minimum Java version is 8.

This is being used by FG7 to apply AccessTransformers to the Minecraft dependency, so it's already useful in reducing code in other projects. I also plan to have this used in FG6 as an optional feature.

Here is the simplest usage:

```gradle
plugins {
    id 'java'
    id 'net.minecraftforge.accesstransformers'
}

accessTransformers.register {
    config = project.file('accesstransformer.cfg')
}

dependencies {
    compileOnly accessTransformers.dep(libs.example)
}
```

Please do not merge through GitHub.com. Instead, rebase/fast-forward and push with the `gradle-1.0` tag.